### PR TITLE
fix(vis-geometry): Adds missing functionality from `bkp-client`

### DIFF
--- a/packages/geometry/src/Rectangle2D.ts
+++ b/packages/geometry/src/Rectangle2D.ts
@@ -24,3 +24,12 @@ export const scaleFromPoint = (rect: rectangle2D, scale: number, point: vec2) =>
     size: Vec2.scale(rect.size, scale),
   };
 };
+
+// linearly interpolate start --> end
+export function interpolateRectangles<T extends rectangle2D>(start: T, end: T, parameter: number): T {
+    return {
+        ...start,
+        center: Vec2.mix(start.center, end.center, parameter),
+        size: Vec2.mix(start.size, end.size, parameter),
+    };
+}

--- a/packages/geometry/src/vector.ts
+++ b/packages/geometry/src/vector.ts
@@ -94,6 +94,7 @@ export type VectorLib<T> = Readonly<{
     floor: unaryOp<T>;
     ceil: unaryOp<T>;
     scale: scalarOp<T>;
+    mix: (a: T, b: T, p: number) => T;
     sum: reduceOp<T>;
     dot: (a: T, b: T) => number;
     length: reduceOp<T>;
@@ -119,6 +120,7 @@ export function VectorLibFactory<V extends VectorConstraint>(): VectorLib<V> {
     const floor = componentUnaryOpFn<V>((a) => Math.floor(a));
     const ceil = componentUnaryOpFn<V>((a) => Math.ceil(a));
     const scale = scalarOpFn<V>((a, b) => a * b);
+    const mix = (a: V, b: V, p: number) => add(scale(a, 1.0 - p), scale(b, p));
     const sum = reduceComponentOpFn<V>((a, b) => a + b);
     const minComponent = reduceComponentOpFn<V>((a, b) => Math.min(a, b));
     const maxComponent = reduceComponentOpFn<V>((a, b) => Math.max(a, b));
@@ -147,6 +149,7 @@ export function VectorLibFactory<V extends VectorConstraint>(): VectorLib<V> {
         floor,
         ceil,
         scale,
+        mix,
         sum,
         dot,
         length,


### PR DESCRIPTION
Adds some missing functions that had been added to the `bkp-client` `geometry` utils in the last month or so. I pulled directly from the code, there weren't any accompanying tests.

I'm thinking we flesh tests out later, since these work and I'd like to integrate the library first, then we'll go crazy on polishing tests, formatting, linting, automated publishing, etc.