### PR TITLE
chore: Add Allen Institute license

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,33 @@
+Allen Institute Software License – This software license is the 2-clause BSD 
+license plus clause a third clause that prohibits redistribution and use for 
+commercial purposes without further permission. 
+
+Copyright © 2019. Allen Institute.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without 
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this 
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, 
+this list of conditions and the following disclaimer in the documentation 
+and/or other materials provided with the distribution.
+
+3. Redistributions and use for commercial purposes are not permitted without 
+the Allen Institute’s written permission. For purposes of this license, 
+commercial purposes are the incorporation of the Allen Institute's software 
+into anything for which you will charge fees or other compensation or use of 
+the software to perform a commercial service for a third party. Contact 
+terms@alleninstitute.org for commercial licensing opportunities.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE 
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.


### PR DESCRIPTION
# chore: Add Allen Institute license

Forgot we have an Institute-wide license that we'll add for now. We'll revisit the license once this is ready to open source.