### PR TITLE
fix: Expose Rectangle2D functions, remove glob export from Interval

### DIFF
--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -11,5 +11,5 @@ export type { box2D } from "./box2D";
 export { Box3D } from "./box3D";
 export type { box3D } from "./box3D";
 export { size, within, isFinite, isValid, fixOrder, intersection, limit } from "./interval";
-export type { box } from './BoundingBox'
+export type { box } from './BoundingBox';
 export { getMinimumBoundingBox, scaleFromPoint, interpolateRectangles } from './Rectangle2D';


### PR DESCRIPTION
# fix: Expose Rectangle2D functions, remove glob export from Interval

I tried integrating the updated library with `bkp-client` and we weren't exposing all the right things!