### PR TITLE
chore: Add contributing and code of conduct documentation [DT-5996]

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,7 +6,7 @@ In the interest of fostering an open and welcoming environment, we as
 contributors and maintainers pledge to make participation in our project and
 our community a harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
+level of experience, education, socio-economic status, nationality, veteran status, personal
 appearance, race, religion, or sexual identity and orientation.
 
 ## Our Standards
@@ -60,7 +60,7 @@ reported to the community leaders responsible for enforcement at <appdev@allenin
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+reporter of any incident. Reporters will face no negative actions for voicing concerns.
 
 ## Enforcement Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,13 +84,13 @@ We use GitHub issues to track bugs and errors. If you run into an issue with the
 
 -   Open an [Issue](https://github.com/AllenInstitute/vis/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 -   Explain the behavior you would expect and the actual behavior.
--   Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
+-   Please provide as much context as possible and describe the _reproduction steps_ that someone else can follow to recreate the issue on their own. This usually includes your code. For good issue reports you should isolate the problem and create a reduced test case.
 -   Provide the information you collected in the previous section.
 
 Once it's filed:
 
 -   The project team will label the issue accordingly.
--   A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Bugs with the `needs-repro` tag will not be addressed until they are reproduced.
+-   A team member will try to reproduce the issue with your provided steps. If there are no reproduction steps or no obvious way to reproduce the issue, the team will ask you for those steps and mark the issue as `needs-repro`. Issues with the `needs-repro` tag will not be addressed until they are reproduced.
 -   If the team is able to reproduce the issue, it will be marked `needs-fix`, as well as possibly other tags (such as `critical`), and the issue will be left to be [implemented by someone](#your-first-code-contribution).
 
 ### Suggesting Enhancements
@@ -116,7 +116,6 @@ Enhancement suggestions are tracked as [GitHub issues](https://github.com/AllenI
 -   Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
 -   **Describe the current behavior** and **explain which behavior you expected to see instead** and why. At this point you can also tell which alternatives do not work for you.
 -   You may want to **include screenshots and animated GIFs** which help you demonstrate the steps or point out the part which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-
 -   **Explain why this enhancement would be useful** to most Visualization Toolkit users. You may also want to point out the other projects that solved it better and which could serve as inspiration.
 
 ### Your First Code Contribution
@@ -125,13 +124,13 @@ If you have a recent version of Node and a code editor, you should be able to ru
 
 ### Improving The Documentation
 
-Documentation improvements are incredibly helpful and welcome. At the moment, we use markdown files on the `docs` folder to document key pieces of the project. At some point we would like to move to a more structured documentation system, but for now, markdown is the way to go when creating new documentation.
+Documentation improvements are incredibly helpful and welcome. At the moment, we use markdown files in the `docs` folder to document key pieces of the project. At some point we would like to move to a more structured documentation system, but for now, markdown is the way to go when creating new documentation.
 
 ## Styleguides
 
 ### Linting and Formatting
 
-We use a linter and code formatter on the project and check for errors. That will largely keep the code style consistent. Make sure to run those checks and fix any issues when opening a PR!
+We use a linter and code formatter on the project to check for errors. That will largely keep the code style consistent. Make sure to run those checks and fix any issues when opening a PR!
 
 ### Commit Messages
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ For details on running or adding new examples, see the `docs/examples.md` file.
 
 Contributions are welcome! We're currently breaking apart the Scatterbrain component into smaller, more manageable packages. If you have a package that you think would be useful to others, please open a PR.
 
-See the CONTRIBUTING.md file for more information on how to contribute to the project
+See the CONTRIBUTING.md file for more information on how to contribute to the project!
 
 # Installation for Development
 


### PR DESCRIPTION
# chore: Add contributing and code of conduct documentation

## What
Added `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` to prepare us for open-sourcing the codebase

## How
Used a popular generator site and tweaked it: https://generator.contributing.md/