### PR TITLE
chore: Remove only-allow so builds stop failing

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -29,7 +29,6 @@
     "types": "lib/index.d.ts",
     "private": true,
     "scripts": {
-        "preinstall": "npx only-allow pnpm",
         "typecheck": "tsc --noEmit",
         "dev": "vite"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@alleninstitute/vis",
     "scripts": {
-        "preinstall": "npx only-allow pnpm",
         "build": "pnpm -r run --no-bail build",
         "watch": "pnpm -r run watch",
         "fmt": "npx prettier . --write",

--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -28,7 +28,6 @@
         "dist"
     ],
     "scripts": {
-        "preinstall": "npx only-allow pnpm",
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "watch": "parcel watch",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -32,7 +32,6 @@
         "dist"
     ],
     "scripts": {
-        "preinstall": "npx only-allow pnpm",
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "watch": "parcel watch",

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -28,7 +28,6 @@
         "dist"
     ],
     "scripts": {
-        "preinstall": "npx only-allow pnpm",
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "dev": "vite",

--- a/packages/scatterbrain/package.json
+++ b/packages/scatterbrain/package.json
@@ -32,7 +32,6 @@
         "dist"
     ],
     "scripts": {
-        "preinstall": "npx only-allow pnpm",
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "watch": "parcel watch",


### PR DESCRIPTION
# What

- Removes `only-allow` since it's causing the `bkp-client` builds to fail intermittently and I haven't been able to find a fix

# How

- Deleted the `preinstall` scripts

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
