### PR TITLE
chore: Version bumps for only-allow removal release

### DIFF
--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -30,7 +30,7 @@ When you have changes to an existing package that you want to publish, follow th
 
 1. Authenticate with GitHub Packages by following the instructions in the [Authenticating with GitHub Packages](authenticating.md) documentation.
 
-2. Update the version number in the `package.json` file, following the [Semantic Versioning standard](https://semver.org/). Remember to run `pnpm install` to get the lock file updated as well!
+2. Update the version number in the `package.json` file, following the [Semantic Versioning standard](https://semver.org/).
 
 3. Get that version number update onto the `main` branch and make sure everything is ship-shape for publishing.
 

--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-dzi",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "contributors": [
         {
             "name": "Lane Sawyer",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-geometry",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "contributors": [
         {
             "name": "Lane Sawyer",

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-omezarr",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "contributors": [
         {
             "name": "Lane Sawyer",

--- a/packages/scatterbrain/package.json
+++ b/packages/scatterbrain/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-scatterbrain",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "contributors": [
         {
             "name": "Lane Sawyer",


### PR DESCRIPTION
# What

- Bump version numbers across all packages so we can release versions that don't have `only-allow` so that our Amplify builds stop failing

# How

- Numbers go up!

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
