### PR TITLE
fix: Limit each package.json to 2 dependabot updates a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,13 @@
 version: 2
 updates:
+    open-pull-requests-limit: 5
+
     # We need to point to each package.json, so this file will be a bit verbose
 
     # Root package.json
     - package-ecosystem: 'npm'
       directory: '/'
+      open-pull-requests-limit: 2
       schedule:
           interval: 'monthly'
       reviewers:
@@ -15,6 +18,7 @@ updates:
     # Packages
     - package-ecosystem: 'npm'
       directory: '/packages/dzi'
+      open-pull-requests-limit: 2
       schedule:
           interval: 'monthly'
       reviewers:
@@ -24,6 +28,7 @@ updates:
 
     - package-ecosystem: 'npm'
       directory: '/packages/geometry'
+      open-pull-requests-limit: 2
       schedule:
           interval: 'monthly'
       reviewers:
@@ -33,6 +38,7 @@ updates:
     
     - package-ecosystem: 'npm'
       directory: '/packages/omezarr'
+      open-pull-requests-limit: 2
       schedule:
           interval: 'monthly'
       reviewers:
@@ -42,6 +48,7 @@ updates:
     
     - package-ecosystem: 'npm'
       directory: '/packages/scatterbrain'
+      open-pull-requests-limit: 2
       schedule:
           interval: 'monthly'
       reviewers:
@@ -52,6 +59,7 @@ updates:
     # Examples
     - package-ecosystem: 'npm'
       directory: '/examples'
+      open-pull-requests-limit: 2
       schedule:
           interval: 'monthly'
       reviewers:


### PR DESCRIPTION
# What

- Limits each Dependabot `package.json` update to 2 PRs a month
- Unfortunately there isn't a repo-wide setting, so we may revist the number depending on how many packages are in each and how often the ones we use are getting updated

# How

- Added `open-pull-requests-limit: 2` to the configs

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
