### PR TITLE
fix: CI tests weren't running [DT-7060]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,6 +97,9 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            - name: Build libraries
+              run: pnpm build
+
             - name: Test
               run: pnpm test
 

--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -29,7 +29,8 @@
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "watch": "parcel watch",
-        "test": "vitest --watch"
+        "test": "vitest --watch",
+        "test:ci": "vitest run"
     },
     "repository": {
         "type": "git",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -33,7 +33,8 @@
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "watch": "parcel watch",
-        "test": "vitest --watch"
+        "test": "vitest --watch",
+        "test:ci": "vitest run"
     },
     "repository": {
         "type": "git",

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -29,7 +29,8 @@
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "dev": "vite",
-        "test": "vitest --watch"
+        "test": "vitest --watch",
+        "test:ci": "vitest run"
     },
     "repository": {
         "type": "git",

--- a/packages/scatterbrain/package.json
+++ b/packages/scatterbrain/package.json
@@ -33,7 +33,8 @@
         "typecheck": "tsc --noEmit",
         "build": "parcel build --no-cache",
         "watch": "parcel watch",
-        "test": "vitest --watch"
+        "test": "vitest --watch",
+        "test:ci": "vitest run"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
# What

- Apparently we didn't actually have a `test:ci` command, so the `test` CI step was just saying "there's nothing to do" lol

# How

- Adds `"test:ci": "vitest run"` to run the tests (the `run` command on `vitest` doesn't enter `watch` mode)
- Added `build` step to the tests so that the libraries are all ready to be used by higher-level packages

# Screenshots
<img width="865" alt="image" src="https://github.com/user-attachments/assets/09009fdd-caec-4b3d-bee5-064f2611db5d" />

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
