### PR TITLE
chore: Fix all but non-null assertion lints

### DIFF
--- a/packages/dzi/src/loader.ts
+++ b/packages/dzi/src/loader.ts
@@ -126,7 +126,7 @@ const logBaseHalf = (x: number) => Math.log2(x) / Math.log2(0.5);
 
 export function imageSizeAtLayer(dzi: DziImage, layer: number) {
     const { size: dim } = dzi;
-    const layerMaxSize = 2 ** (isFinite(layer) ? Math.max(0, layer) : 0);
+    const layerMaxSize = 2 ** (Number.isFinite(layer) ? Math.max(0, layer) : 0);
     const size: vec2 = [dim.width, dim.height];
     // the question is how many times do we need to divide size
     // by 2 to make it less than layerMaxSize?

--- a/packages/geometry/src/index.ts
+++ b/packages/geometry/src/index.ts
@@ -13,7 +13,7 @@ export type { box3D } from './box3D';
 export {
     size,
     within,
-    isFinite,
+    isFiniteInterval,
     isValid,
     fixOrder,
     intersection,

--- a/packages/geometry/src/interval.ts
+++ b/packages/geometry/src/interval.ts
@@ -25,7 +25,7 @@ export function within(i: Interval, x: number): boolean {
  * @param i a given interval
  * @returns true iff its min and max values are both finite, non-NaN values
  */
-export function isFinite(i: Interval) {
+export function isFiniteInterval(i: Interval) {
     return Number.isFinite(i.min) && Number.isFinite(i.max);
 }
 /**
@@ -35,7 +35,7 @@ export function isFinite(i: Interval) {
  * @return true iff the given interval i is at least as big as minSize, and min <= max, and isFinite(i)
  */
 export function isValid(i: Interval, minSize: number) {
-    return size(i) >= Math.abs(minSize) && isFinite(i) && i.max >= i.min;
+    return size(i) >= Math.abs(minSize) && isFiniteInterval(i) && i.max >= i.min;
 }
 /**
  *

--- a/packages/geometry/src/spatialIndexing/tree.ts
+++ b/packages/geometry/src/spatialIndexing/tree.ts
@@ -16,12 +16,12 @@ export function visitBFS<Tree>(
     while (frontier.length > 0) {
         const cur = frontier.shift()!;
         visitor(cur);
-        children(cur).forEach((c) => {
+        for (const c of children(cur)) {
             if (traversalPredicate?.(c) ?? true) {
                 // predicate?.(c) is true false or undefined. if its undefined, we coerce it to true with ??
                 // because we want to always traverse children if the predicate isn't given
                 frontier.push(c);
             }
-        });
+        }
     }
 }

--- a/packages/omezarr/src/zarr-data.ts
+++ b/packages/omezarr/src/zarr-data.ts
@@ -184,14 +184,14 @@ export function sizeInUnits(
     let size: vec2 = vxls;
     // now, just apply the correct transforms, if they exist...
 
-    dataset.coordinateTransformations.forEach((trn) => {
+    for (const trn of dataset.coordinateTransformations) {
         if (isScaleTransform(trn)) {
             // try to apply it!
             const uIndex = indexOfDimension(axes, planeUV.u);
             const vIndex = indexOfDimension(axes, planeUV.v);
             size = Vec2.mul(size, [trn.scale[uIndex], trn.scale[vIndex]]);
         }
-    });
+    }
     return size;
 }
 /**
@@ -247,7 +247,8 @@ function buildQuery(r: Readonly<ZarrRequest>, axes: readonly AxisDesc[], shape: 
         const bounds = { min: 0, max: shape[i] };
         if (d === null) {
             return d;
-        } else if (typeof d === 'number') {
+        }
+        if (typeof d === 'number') {
             return limit(bounds, d);
         }
         return zarr.slice(limit(bounds, d.min), limit(bounds, d.max));
@@ -285,7 +286,7 @@ export async function getSlice(metadata: ZarrDataset, r: ZarrRequest, layerIndex
     const level = scene.datasets[layerIndex] ?? scene.datasets[scene.datasets.length - 1];
     const arr = await zarr.open(root.resolve(level.path), { kind: 'array' });
     const result = await zarr.get(arr, buildQuery(r, axes, level.shape));
-    if (typeof result == 'number') {
+    if (typeof result === 'number') {
         throw new Error('oh noes, slice came back all weird');
     }
     return {

--- a/packages/scatterbrain/src/abstract/async-frame.ts
+++ b/packages/scatterbrain/src/abstract/async-frame.ts
@@ -118,7 +118,9 @@ export function beginFrame<
         const startWorkTime = performance.now();
         const cleanupOnError = (err: unknown) => {
             // clear the queue and the staging area (inFlight)
-            taskCancelCallbacks.forEach((cancelMe) => cancelMe());
+            for (const cancelMe of taskCancelCallbacks) {
+                cancelMe();
+            }
             queue.splice(0, queue.length);
             // stop fetching
             abort.abort(err);
@@ -173,7 +175,9 @@ export function beginFrame<
     return {
         cancelFrame: (reason?: string) => {
             abort.abort(new DOMException(reason, 'AbortError'));
-            taskCancelCallbacks.forEach((cancelMe) => cancelMe());
+            for (const cancelMe of taskCancelCallbacks) {
+                cancelMe();
+            }
             clearInterval(interval);
             reportStatus({ status: 'cancelled' }, true);
         },

--- a/packages/scatterbrain/src/abstract/render-server.ts
+++ b/packages/scatterbrain/src/abstract/render-server.ts
@@ -160,7 +160,7 @@ export class RenderServer {
     beginRendering<D, I>(renderFn: RenderFrameFn<D, I>, callback: ServerCallback<D, I>, client: Client) {
         if (this.regl) {
             const clientFrame = this.clients.get(client);
-            if (clientFrame && clientFrame.frame) {
+            if (clientFrame?.frame) {
                 clientFrame.frame.cancelFrame();
                 this.regl.clear({
                     framebuffer: clientFrame.image,

--- a/packages/scatterbrain/src/dataset-cache.ts
+++ b/packages/scatterbrain/src/dataset-cache.ts
@@ -85,7 +85,9 @@ export class AsyncDataCache<SemanticKey extends RecordKey, CacheKey extends Reco
     private usedSpace() {
         // Map uses iterators, so we're in for-loop territory here
         let sum = 0;
-        this.entries.forEach((entry) => (sum += entry.data instanceof Promise ? 0 : this.size(entry.data)));
+        for (const entry of this.entries.values()) {
+            sum += entry.data instanceof Promise ? 0 : this.size(entry.data);
+        }
         return sum;
     }
     private countRequests() {
@@ -201,7 +203,9 @@ export class AsyncDataCache<SemanticKey extends RecordKey, CacheKey extends Reco
                 removeUs.push(req);
             }
         }
-        removeUs.forEach((finished) => this.pendingRequests.delete(finished));
+        for (const finished of removeUs) {
+            this.pendingRequests.delete(finished);
+        }
     }
     private prepareCache(semanticKey: SemanticKey, cacheKey: CacheKey, getter: () => Promise<D>) {
         let promise: Promise<D>;
@@ -243,13 +247,13 @@ export class AsyncDataCache<SemanticKey extends RecordKey, CacheKey extends Reco
             runner: use,
             blocking: new Set<CacheKey>(),
         };
-        keys.forEach((k) => {
+        for (const k of keys) {
             if (req.awaiting.has(toCacheKey(k))) {
                 req.awaiting.get(toCacheKey(k))?.add(k);
             } else {
                 req.awaiting.set(toCacheKey(k), new Set<SemanticKey>([k]));
             }
-        });
+        }
         for (const semanticKey of keys) {
             const result = this.prepareCache(semanticKey, toCacheKey(semanticKey), workingSet[semanticKey]);
             if (result instanceof Promise) {

--- a/packages/scatterbrain/src/layers/layer-2D.ts
+++ b/packages/scatterbrain/src/layers/layer-2D.ts
@@ -47,7 +47,7 @@ export class ReglLayer2D<Renderable, RenderSettings extends RequiredSettings> {
     }
 
     getRenderResults(stage: 'prev' | 'cur') {
-        return stage == 'cur' ? this.buffers.writeTo : this.buffers.readFrom;
+        return stage === 'cur' ? this.buffers.writeTo : this.buffers.readFrom;
     }
     onChange(
         props: {

--- a/packages/scatterbrain/src/render-queue.ts
+++ b/packages/scatterbrain/src/render-queue.ts
@@ -124,7 +124,9 @@ export function beginLongRunningFrame<Column, Item, Settings>(
         const startWorkTime = performance.now();
         const cleanupOnError = (err: unknown) => {
             // clear the queue and the staging area (inFlight)
-            taskCancelCallbacks.forEach((cancelMe) => cancelMe());
+            for (const cancelMe of taskCancelCallbacks) {
+                cancelMe();
+            }
             queue.splice(0, queue.length);
             // stop fetching
             abort.abort(err);
@@ -173,7 +175,9 @@ export function beginLongRunningFrame<Column, Item, Settings>(
     // touched/referenced after cancellation, unless the author of render() did some super weird bad things
     return {
         cancelFrame: (reason?: string) => {
-            taskCancelCallbacks.forEach((cancelMe) => cancelMe());
+            for (const cancelMe of taskCancelCallbacks) {
+                cancelMe();
+            }
             abort.abort(new DOMException(reason, 'AbortError'));
             clearInterval(interval);
             reportNormalStatus('cancelled');


### PR DESCRIPTION
# What

- Fixes all remaining lints besides the "non-null assertion" lints
- Leaves those 9 assertions for another time. We'll need to decide how to respond in each case if the item is undefined

# How

- `pnpm lint`
- Look at the problems
- Most of the time Biome suggested a solution and it worked perfectly!

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
