### PR TITLE
chore: Update vis-omezarr 0.0.7 - upgrade zarrita to 0.5.0

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -62,7 +62,7 @@
         "react-dom": "18.3.0",
         "react-router": "7.0.2",
         "regl": "2.1.0",
-        "zarrita": "0.4.0-next.14"
+        "zarrita": "0.5.0"
     },
     "packageManager": "pnpm@9.14.2"
 }

--- a/examples/src/common/loaders/ome-zarr/fetchSlice.worker.ts
+++ b/examples/src/common/loaders/ome-zarr/fetchSlice.worker.ts
@@ -1,6 +1,6 @@
 import { type ZarrDataset, type ZarrRequest, getSlice } from '@alleninstitute/vis-omezarr';
 // a web-worker which fetches slices of data, decodes them, and returns the result as a flat float32 array, using transferables
-import type { Chunk } from 'zarrita';
+import type { Chunk, Float32 } from 'zarrita';
 
 const ctx = self;
 type ZarrSliceRequest = {
@@ -18,7 +18,7 @@ ctx.onmessage = (msg: MessageEvent<unknown>) => {
     try {
         if (isSliceRequest(data)) {
             const { metadata, req, layerIndex, id } = data;
-            getSlice(metadata, req, layerIndex).then((result: { shape: number[]; buffer: Chunk<'float32'> }) => {
+            getSlice(metadata, req, layerIndex).then((result: { shape: number[]; buffer: Chunk<Float32> }) => {
                 const { shape, buffer } = result;
                 const flaots = new Float32Array(buffer.data);
                 ctx.postMessage({ type: 'slice', id, shape, data: flaots }, { transfer: [flaots.buffer] });

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-omezarr",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "contributors": [
         {
             "name": "Lane Sawyer",
@@ -47,7 +47,7 @@
         "@alleninstitute/vis-geometry": "workspace:*",
         "@alleninstitute/vis-scatterbrain": "workspace:*",
         "regl": "2.1.0",
-        "zarrita": "0.4.0-next.14"
+        "zarrita": "0.5.0"
     },
     "packageManager": "pnpm@9.14.2"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,8 +147,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       zarrita:
-        specifier: 0.4.0-next.14
-        version: 0.4.0-next.14
+        specifier: 0.5.0
+        version: 0.5.0
 
   packages/scatterbrain:
     dependencies:
@@ -1291,6 +1291,9 @@ packages:
   '@zarrita/indexing@0.1.0-next.19':
     resolution: {integrity: sha512-GRu6CxtEeXnZUYR0Z/sEGFPcll7pG2Ek9muUkdpl5U5fUdPW7YaSj1tMBxDFhkgw9MNy87ksnN2VO4Tgjjl5fw==}
 
+  '@zarrita/storage@0.1.0':
+    resolution: {integrity: sha512-lSGDQik2fLt/UyvWzWd23sJFHckEmk50F9Baz2XlbgFQhvd2EVBcHGweOTBhu3c5SB05TzOnlY1M1i2FMDi6YA==}
+
   '@zarrita/storage@0.1.0-next.8':
     resolution: {integrity: sha512-9d8bIaR2JuiG98gg5lF15Tpgc/+G/XOXlY53UtVP0LABwHbrIGFzpO2djzGB5bQe1jDj92VeXE8Z525Bs2vb6Q==}
 
@@ -2084,6 +2087,9 @@ packages:
 
   zarrita@0.4.0-next.14:
     resolution: {integrity: sha512-B5a3Nw31EEaxjI0yh+CJuSdqDo3f0KnCrf8aZiDj4Nhrsi/Jau7Mtc7Yo6T3SmM6AInTmA/VNv/FKT5ZLfADTQ==}
+
+  zarrita@0.5.0:
+    resolution: {integrity: sha512-wyvnnzeXh9rBCZxsn6GEW4oXDv3LD2f4KSJ6LLFjYaMNtmAtaSt3qEO3fHuuq0VZWUGb8cjTYDEtwJTa09wp6g==}
 
 snapshots:
 
@@ -3391,6 +3397,11 @@ snapshots:
       '@zarrita/storage': 0.1.0-next.8
       '@zarrita/typedarray': 0.1.0-next.4
 
+  '@zarrita/storage@0.1.0':
+    dependencies:
+      reference-spec-reader: 0.2.0
+      unzipit: 1.4.3
+
   '@zarrita/storage@0.1.0-next.8':
     dependencies:
       reference-spec-reader: 0.2.0
@@ -4147,3 +4158,8 @@ snapshots:
       '@zarrita/core': 0.1.0-next.17
       '@zarrita/indexing': 0.1.0-next.19
       '@zarrita/storage': 0.1.0-next.8
+
+  zarrita@0.5.0:
+    dependencies:
+      '@zarrita/storage': 0.1.0
+      numcodecs: 0.3.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,8 +99,8 @@ importers:
         specifier: 2.1.0
         version: 2.1.0
       zarrita:
-        specifier: 0.4.0-next.14
-        version: 0.4.0-next.14
+        specifier: 0.5.0
+        version: 0.5.0
     devDependencies:
       '@types/file-saver':
         specifier: 2.0.7
@@ -1285,20 +1285,8 @@ packages:
   '@vitest/utils@3.0.7':
     resolution: {integrity: sha512-xePVpCRfooFX3rANQjwoditoXgWb1MaFbzmGuPP59MK6i13mrnDw/yEIyJudLeW6/38mCNcwCiJIGmpDPibAIg==}
 
-  '@zarrita/core@0.1.0-next.17':
-    resolution: {integrity: sha512-VTf1KWLz3vqX4IUdg1lJYBpHo/cT3NbpFQ47JOCEaVsmGv09So5yY7UkXPTQ6ef7oy9BFven7sD5EKSutiFn8A==}
-
-  '@zarrita/indexing@0.1.0-next.19':
-    resolution: {integrity: sha512-GRu6CxtEeXnZUYR0Z/sEGFPcll7pG2Ek9muUkdpl5U5fUdPW7YaSj1tMBxDFhkgw9MNy87ksnN2VO4Tgjjl5fw==}
-
   '@zarrita/storage@0.1.0':
     resolution: {integrity: sha512-lSGDQik2fLt/UyvWzWd23sJFHckEmk50F9Baz2XlbgFQhvd2EVBcHGweOTBhu3c5SB05TzOnlY1M1i2FMDi6YA==}
-
-  '@zarrita/storage@0.1.0-next.8':
-    resolution: {integrity: sha512-9d8bIaR2JuiG98gg5lF15Tpgc/+G/XOXlY53UtVP0LABwHbrIGFzpO2djzGB5bQe1jDj92VeXE8Z525Bs2vb6Q==}
-
-  '@zarrita/typedarray@0.1.0-next.4':
-    resolution: {integrity: sha512-sGqc5Ldh8nt/FE9gDA89OsL+FH37wgSxCF1Liv08O8SbZ4w3N48Wngv0EWAXvU1aSEdGhb2ABtSfErVDwnp45Q==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -2084,9 +2072,6 @@ packages:
   yaml@1.10.2:
     resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
     engines: {node: '>= 6'}
-
-  zarrita@0.4.0-next.14:
-    resolution: {integrity: sha512-B5a3Nw31EEaxjI0yh+CJuSdqDo3f0KnCrf8aZiDj4Nhrsi/Jau7Mtc7Yo6T3SmM6AInTmA/VNv/FKT5ZLfADTQ==}
 
   zarrita@0.5.0:
     resolution: {integrity: sha512-wyvnnzeXh9rBCZxsn6GEW4oXDv3LD2f4KSJ6LLFjYaMNtmAtaSt3qEO3fHuuq0VZWUGb8cjTYDEtwJTa09wp6g==}
@@ -3385,29 +3370,10 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@zarrita/core@0.1.0-next.17':
-    dependencies:
-      '@zarrita/storage': 0.1.0-next.8
-      '@zarrita/typedarray': 0.1.0-next.4
-      numcodecs: 0.3.2
-
-  '@zarrita/indexing@0.1.0-next.19':
-    dependencies:
-      '@zarrita/core': 0.1.0-next.17
-      '@zarrita/storage': 0.1.0-next.8
-      '@zarrita/typedarray': 0.1.0-next.4
-
   '@zarrita/storage@0.1.0':
     dependencies:
       reference-spec-reader: 0.2.0
       unzipit: 1.4.3
-
-  '@zarrita/storage@0.1.0-next.8':
-    dependencies:
-      reference-spec-reader: 0.2.0
-      unzipit: 1.4.3
-
-  '@zarrita/typedarray@0.1.0-next.4': {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -4152,12 +4118,6 @@ snapshots:
       stackback: 0.0.2
 
   yaml@1.10.2: {}
-
-  zarrita@0.4.0-next.14:
-    dependencies:
-      '@zarrita/core': 0.1.0-next.17
-      '@zarrita/indexing': 0.1.0-next.19
-      '@zarrita/storage': 0.1.0-next.8
 
   zarrita@0.5.0:
     dependencies:


### PR DESCRIPTION
# What

Updates the `vis-omezarr` dependency `zarrita` to version `0.5.0`. Also updates the version number of `vis-omezarr` to `0.0.7`.

# How

Updates in `package.json`.

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [ ] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [ ] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [x] Chrome (Fully supported)
    -   [ ] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
