### PR TITLE
fix: Actually deploy the examples

### DIFF
--- a/.github/workflows/deploy_examples.yml
+++ b/.github/workflows/deploy_examples.yml
@@ -23,9 +23,6 @@ jobs:
             name: github-pages
             url: ${{ steps.deployment.outputs.page_url }}
         runs-on: ubuntu-latest
-        defaults:
-            run:
-                working-directory: ./examples
         steps:
             - name: Checkout
               uses: actions/checkout@v4
@@ -49,7 +46,7 @@ jobs:
             - name: Upload artifact
               uses: actions/upload-pages-artifact@v3
               with:
-                  path: './dist'
+                  path: './examples/dist'
             - name: Deploy to GitHub Pages
               id: deployment
               uses: actions/deploy-pages@v4


### PR DESCRIPTION
# What

- Fixes deploy by building the whole project so the examples won't fail

# How

- Remove the working directory set to `examples`
- Install and build _everything_
- Point to the `./examples/dist` folder to be the upload artifact

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
