### PR TITLE
chore: Fix deployed example pages 404

### DIFF
--- a/examples/src/app.tsx
+++ b/examples/src/app.tsx
@@ -10,9 +10,9 @@ export function App() {
         <BrowserRouter basename="/vis">
             <Routes>
                 <Route index element={<Home />} />
-                <Route path="/dzi" element={<DziDemo />} />
-                <Route path="/omezarr" element={<OmezarrDemo />} />
-                <Route path="/layers" element={<RedirectToLayersHTML />} />
+                <Route path="dzi" element={<DziDemo />} />
+                <Route path="omezarr" element={<OmezarrDemo />} />
+                <Route path="layers" />
             </Routes>
         </BrowserRouter>
     );

--- a/examples/src/home.tsx
+++ b/examples/src/home.tsx
@@ -15,7 +15,7 @@ export function Home() {
                     <br />
                 </li>
                 <li>
-                    <a href="/vis/layers">Layers</a>
+                    <a href="/vis/layers">Layers (only works on local demo site)</a>
                     <br />
                 </li>
             </ul>


### PR DESCRIPTION
# What
- Fixes the deployed pages
- Adds warning that the layers demo won't work on the deployed site. The Vite dev server does some magic to load `layers.html` but the GitHub Actions server isn't so smart

# How

- Accidentally had a `/` on the routes so the `/vis/[route]` wasn't working
- Tweaked the link label

# Screenshots

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
