### PR TITLE
chore: Updating vis-dzi and vis-omezarr to enable use of vis-scatterbrain 0.0.10

### DIFF
--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-dzi",
-    "version": "0.0.9",
+    "version": "0.0.10",
     "contributors": [
         {
             "name": "Lane Sawyer",

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-omezarr",
-    "version": "0.0.8",
+    "version": "0.0.9",
     "contributors": [
         {
             "name": "Lane Sawyer",


### PR DESCRIPTION
# chore: Updating vis-dzi and vis-omezarr to enable use of vis-scatterbrain 0.0.10

# What

Built versions of 0.0.9 `vis-dzi` and 0.0.8 `vis-omezarr` did not point to `vis-scatterbrain` 0.0.10, so this ensures that the latest versions of these libraries do point at the proper version of Scatterbrain.

# How

Update version numbers so new built packages can be published.

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [ ] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [x] Chrome (Fully supported)
    -   [ ] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
