### PR TITLE
Updating DZI package version (remove Scatterbrain dependency)

### DIFF
--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-dzi",
-    "version": "0.0.10",
+    "version": "0.0.11",
     "contributors": [
         {
             "name": "Lane Sawyer",
@@ -17,6 +17,10 @@
         {
             "name": "Su Li",
             "email": "su.li@alleninstitute.org"
+        },
+        {
+            "name": "Joel Arbuckle",
+            "email": "joel.arbuckle@alleninstitute.org"
         }
     ],
     "license": "BSD-3-Clause",


### PR DESCRIPTION
# Updating DZI package version (remove Scatterbrain dependency)

# What

Since the current published version of DZI still uses Scatterbrain, this update to package version allows the publishing of a version that depends on `vis-core` instead.

# How

Version number go brrrrrrrrr

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [ ] Have you smoke tested the example applications?
-   [ ] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [ ] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
