### PR TITLE
chore: Add helpful linting rules

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -24,6 +24,10 @@
             "recommended": true,
             "suspicious": {
                 "noConsole": "error"
+            },
+            "correctness": {
+                "noUnusedImports": "error",
+                "useHookAtTopLevel": "error"
             }
         }
     },

--- a/examples/src/app.tsx
+++ b/examples/src/app.tsx
@@ -1,9 +1,7 @@
-import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router';
 import { DziDemo } from './dzi/dzi-demo';
 import { Home } from './home';
 import { OmezarrDemo } from './omezarr/omezarr-demo';
-import { RedirectToLayersHTML } from './layers/tempLayers';
 
 export function App() {
     return (

--- a/examples/src/common/image-renderer.ts
+++ b/examples/src/common/image-renderer.ts
@@ -1,4 +1,4 @@
-import type { vec2, vec4 } from '@alleninstitute/vis-geometry';
+import type { vec4 } from '@alleninstitute/vis-geometry';
 import type REGL from 'regl';
 import type { Framebuffer2D } from 'regl';
 

--- a/examples/src/common/react/render-server-provider.tsx
+++ b/examples/src/common/react/render-server-provider.tsx
@@ -1,5 +1,5 @@
 import { logger, RenderServer } from '@alleninstitute/vis-core';
-import React, { createContext, useEffect, useRef, type PropsWithChildren } from 'react';
+import { createContext, useEffect, useRef, type PropsWithChildren } from 'react';
 
 export const renderServerContext = createContext<RenderServer | null>(null);
 

--- a/examples/src/data-renderers/lineRenderer.ts
+++ b/examples/src/data-renderers/lineRenderer.ts
@@ -1,6 +1,5 @@
 import type { box2D, vec2, vec4 } from '@alleninstitute/vis-geometry';
 import type REGL from 'regl';
-import type { AttributeConfig } from 'regl';
 import type { ColumnData } from '~/common/loaders/scatterplot/scatterbrain-loader';
 
 type Attrs = { pos: REGL.AttributeConfig };

--- a/examples/src/data-renderers/scatterplot.ts
+++ b/examples/src/data-renderers/scatterplot.ts
@@ -1,4 +1,4 @@
-import { Box2D, type box2D, type vec2, type vec4 } from '@alleninstitute/vis-geometry';
+import { Box2D, type vec2, type vec4 } from '@alleninstitute/vis-geometry';
 import type REGL from 'regl';
 import type { Framebuffer2D } from 'regl';
 import type { RenderSettings } from '~/common/loaders/scatterplot/data';

--- a/examples/src/dzi/dzi-viewer.tsx
+++ b/examples/src/dzi/dzi-viewer.tsx
@@ -3,12 +3,11 @@ import {
     type DziImage,
     type DziRenderSettings,
     type DziTile,
-    buildAsyncDziRenderer,
-    buildDziRenderer,
+    buildAsyncDziRenderer
 } from '@alleninstitute/vis-dzi';
 import { Vec2, type vec2 } from '@alleninstitute/vis-geometry';
 import type { RenderFrameFn, buildAsyncRenderer } from '@alleninstitute/vis-core';
-import { useContext, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { renderServerContext } from '~/common/react/render-server-provider';
 
 type Props = {

--- a/examples/src/home.tsx
+++ b/examples/src/home.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 
 export function Home() {
     return (

--- a/examples/src/index.tsx
+++ b/examples/src/index.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './app';
 

--- a/examples/src/layers/layers.tsx
+++ b/examples/src/layers/layers.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@czi-sds/components';
-import React from 'react';
 import type { Demo } from '../layers';
 import { AnnotationGrid } from '../ui/annotation-grid';
 import { ContactSheetUI } from '../ui/contact-sheet';

--- a/examples/src/omezarr/omezarr-demo.tsx
+++ b/examples/src/omezarr/omezarr-demo.tsx
@@ -1,13 +1,10 @@
 import {
     Box2D,
-    CartesianPlane,
     type Interval,
     PLANE_XY,
     type box2D,
     type vec2,
-    type vec3,
 } from '@alleninstitute/vis-geometry';
-import { makeRGBColorVector } from '@alleninstitute/vis-core';
 import { type OmeZarrMetadata, loadMetadata, sizeInUnits } from '@alleninstitute/vis-omezarr';
 import type { RenderSettings, RenderSettingsChannels } from '@alleninstitute/vis-omezarr';
 import { logger, type WebResource } from '@alleninstitute/vis-core';

--- a/examples/src/omezarr/sliceview.tsx
+++ b/examples/src/omezarr/sliceview.tsx
@@ -1,4 +1,4 @@
-import { Box2D, CartesianPlane, PLANE_XY, Vec2, Vec3, type box2D } from '@alleninstitute/vis-geometry';
+import { Box2D, PLANE_XY, Vec2, type box2D } from '@alleninstitute/vis-geometry';
 import {
     type RenderSettings,
     type VoxelTile,

--- a/examples/src/ui/annotation-grid.tsx
+++ b/examples/src/ui/annotation-grid.tsx
@@ -1,5 +1,4 @@
 import { InputSlider } from '@czi-sds/components';
-import React from 'react';
 import type { Demo } from 'src/layers';
 export function AnnotationGrid(props: { demo: Demo }) {
     const { demo } = props;

--- a/examples/src/ui/contact-sheet.tsx
+++ b/examples/src/ui/contact-sheet.tsx
@@ -1,5 +1,4 @@
 import { Button, InputSlider } from '@czi-sds/components';
-import React from 'react';
 import type { Demo } from 'src/layers';
 export function ContactSheetUI(props: { demo: Demo }) {
     const { demo } = props;

--- a/examples/src/ui/scatterplot-ui.tsx
+++ b/examples/src/ui/scatterplot-ui.tsx
@@ -1,5 +1,4 @@
 import { InputSlider } from '@czi-sds/components';
-import React, { useState } from 'react';
 import type { Demo } from 'src/layers';
 export function ScatterplotUI(props: { demo: Demo }) {
     const { demo } = props;

--- a/examples/src/ui/slice-ui.tsx
+++ b/examples/src/ui/slice-ui.tsx
@@ -1,5 +1,4 @@
 import { Button, InputSlider } from '@czi-sds/components';
-import React from 'react';
 import type { Demo } from 'src/layers';
 export function SliceViewLayer(props: { demo: Demo }) {
     const { demo } = props;

--- a/packages/core/src/test/render-cache.test.ts
+++ b/packages/core/src/test/render-cache.test.ts
@@ -1,7 +1,6 @@
-import { delay, partial, partialRight, uniqueId } from 'lodash';
+import { partial, uniqueId } from 'lodash';
 import { beforeEach, describe, expect, it } from 'vitest';
 import { AsyncDataCache } from '../dataset-cache';
-import { fakeFetch } from './test-utils';
 type Columns = 'color' | 'position';
 type vec3 = readonly [number, number, number];
 type Data = { pretend: vec3 };

--- a/packages/core/src/test/render-queue.test.ts
+++ b/packages/core/src/test/render-queue.test.ts
@@ -1,5 +1,5 @@
 import delay from 'lodash/delay';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 import { AsyncDataCache } from '../dataset-cache';
 import { type NormalStatus, beginLongRunningFrame } from '../render-queue';
 import { fakeFetch } from './test-utils';

--- a/packages/dzi/src/loader.test.ts
+++ b/packages/dzi/src/loader.test.ts
@@ -1,6 +1,6 @@
 import { Box2D } from '@alleninstitute/vis-geometry';
 import { logger } from '@alleninstitute/vis-core';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { type DziImage, firstSuitableLayer, imageSizeAtLayer, tileWithOverlap, tilesInLayer } from './loader';
 
 describe('tiling math', () => {

--- a/packages/geometry/src/tests/interval.test.ts
+++ b/packages/geometry/src/tests/interval.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { type Interval, fixOrder, intersection, isValid, limit, size, within } from '../interval';
 function I(a: number, b: number): Interval {
     return { min: a, max: b };

--- a/packages/omezarr/src/sliceview/loader.test.ts
+++ b/packages/omezarr/src/sliceview/loader.test.ts
@@ -1,9 +1,8 @@
 // TODO Unit test for loading is no longer feasible, as it requires an actual Zarr group + arrays to resolve correctly.
 // Best bet is to create a proper fake OmeZarr dataset and do a "unit" (really, integration) test that way.
 
-import { Box2D, CartesianPlane, PLANE_XY, PLANE_YZ, type box2D } from '@alleninstitute/vis-geometry';
+import { Box2D, PLANE_XY, PLANE_YZ, type box2D } from '@alleninstitute/vis-geometry';
 import { describe, expect, it } from 'vitest';
-import type * as zarr from 'zarrita';
 import { OmeZarrMetadata } from '../zarr/types';
 import { sizeInUnits } from '../zarr/loading';
 import { getVisibleTiles } from './loader';

--- a/packages/omezarr/src/zarr/loading.ts
+++ b/packages/omezarr/src/zarr/loading.ts
@@ -8,7 +8,7 @@ import {
     type vec2,
 } from '@alleninstitute/vis-geometry';
 import { getResourceUrl, logger, type WebResource } from '@alleninstitute/vis-core';
-import { VisZarrDataError, VisZarrError } from '../errors';
+import { VisZarrDataError } from '../errors';
 import {
     OmeZarrAttrsSchema,
     OmeZarrMetadata,

--- a/packages/omezarr/src/zarr/types.ts
+++ b/packages/omezarr/src/zarr/types.ts
@@ -1,7 +1,6 @@
-import { Vec4, type CartesianPlane, type Interval, type vec3, type vec4 } from '@alleninstitute/vis-geometry';
+import type { CartesianPlane, Interval, vec3, vec4 } from '@alleninstitute/vis-geometry';
 import { VisZarrDataError, VisZarrIndexError } from '../errors';
-import { logger, makeRGBAColorVector, makeRGBColorVector } from '@alleninstitute/vis-core';
-import type * as zarr from 'zarrita';
+import { logger, makeRGBAColorVector } from '@alleninstitute/vis-core';
 import { z } from 'zod';
 
 export type ZarrDimension = 't' | 'c' | 'z' | 'y' | 'x';


### PR DESCRIPTION
# What

- Improves linting setup

# How

- Adds the `noUnusedImports` rule to keep imports tidy and accurate
- Adds the `useHookAtTopLevel` rule to enforce the Rules of Hooks in React components
- Ran `pnpm lint` to automatically fix any errors (only had import errors, no rules of hooks errors!)

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
