### PR TITLE
chore: Fix deployed examples site

### DIFF
--- a/examples/src/app.tsx
+++ b/examples/src/app.tsx
@@ -12,7 +12,7 @@ export function App() {
                 <Route index element={<Home />} />
                 <Route path="dzi" element={<DziDemo />} />
                 <Route path="omezarr" element={<OmezarrDemo />} />
-                <Route path="layers" />
+                {/* LAYERS intentionally missing, needs to be migrated to a React component */}
             </Routes>
         </BrowserRouter>
     );

--- a/examples/src/home.tsx
+++ b/examples/src/home.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router';
 
 export function Home() {
     return (
@@ -7,15 +8,16 @@ export function Home() {
             <br />
             <ul>
                 <li>
-                    <a href="/vis/dzi">Deep Zoom Image</a>
+                    <Link to="dzi">Deep Zoom Image</Link>
                     <br />
                 </li>
                 <li>
-                    <a href="/vis/omezarr">OMEZARR</a>
+                    <Link to="omezarr">OMEZARR</Link>
                     <br />
                 </li>
                 <li>
-                    <a href="/vis/layers">Layers (only works on local demo site)</a>
+                    {/* NOT A REACT ROUTER LINK until we migrate it to a React component */}
+                    <a href="/vis/layers">Layers</a>
                     <br />
                 </li>
             </ul>

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -1,6 +1,29 @@
 import path from 'node:path';
+import fs from 'node:fs';
 import react from '@vitejs/plugin-react-swc';
 import { defineConfig } from 'vite';
+
+// To support the layers demo we need to include the layers.html file in the build,
+// which we do by configuring Rollup to use any HTML files in the /examples directory
+function getHtmlEntries() {
+    const pagesDir = path.resolve(__dirname, '');
+    const entries = {};
+
+    // Read all files in the directory
+    const files = fs.readdirSync(pagesDir);
+
+    // Filter out HTML files
+    const htmlFiles = files.filter((file) => file.endsWith('.html'));
+
+    // Create entries for each HTML file
+    for (const file of htmlFiles) {
+        const name = path.basename(file, '.html');
+        entries[name] = path.resolve(pagesDir, file);
+    }
+
+    return entries;
+}
+
 // https://vitejs.dev/config/
 export default defineConfig({
     // `base` enables GitHub Pages deployment to function
@@ -10,5 +33,18 @@ export default defineConfig({
         alias: {
             '~': path.resolve(__dirname, './src'),
         },
+    },
+    // Used to get the layers.html file in the build, remove once it's migrated to a React component
+    build: {
+        rollupOptions: {
+            input: getHtmlEntries(),
+            output: {
+                format: 'es',
+            },
+        },
+    },
+    // Needed for the Rollup build changes to work
+    worker: {
+        format: 'es', // Explicitly set worker format to ES modules
     },
 });


### PR DESCRIPTION
# What

- Fixes the deployed example website to render all the pages
- **Note:** It's hard to _prove_ this works, so we'll have to deploy to fully see, but I do see `layers.html` in the `dist` upon building the site now, so this should work 🤞🏻

# How

- Use the React Router `Link` component for the links so that the `/vis` prefixing is handled correctly once it's deployed to a static site (the local `dev` server was compensating for some of the errors but that Vite magic is not available for GitHub Pages)
- Included the `layers.html` file in the final build so that demo will work
- Removed `/layers` from React Router's config, as it's simply an entirely new "app" given the way it was initially written

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [ ] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
