### PR TITLE
fix: Parse axis name to match our internal casing [134]

### DIFF
--- a/packages/omezarr/src/zarr/types.test.ts
+++ b/packages/omezarr/src/zarr/types.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { CartesianPlane } from '@alleninstitute/vis-geometry';
+import { OmeZarrAxisSchema } from './types';
+
+describe('OmeZarrAxisSchema', () => {
+    it('should convert the axis name to lowercase when parsed to match our Cartesian Plane', () => {
+        const result = OmeZarrAxisSchema.parse({
+            name: 'X',
+            type: 'space',
+        });
+
+        // Create a concrete CartesianPlane to compare with so we know the parsed data will interop correctly
+        const plane = new CartesianPlane('xy');
+        expect(result.name).toBe(plane.u);
+    });
+});

--- a/packages/omezarr/src/zarr/types.ts
+++ b/packages/omezarr/src/zarr/types.ts
@@ -19,7 +19,7 @@ export type OmeZarrAxis = {
 };
 
 export const OmeZarrAxisSchema: z.ZodType<OmeZarrAxis> = z.object({
-    name: z.string(),
+    name: z.string().toLowerCase(),
     type: z.string(),
     scale: z.number().optional(),
     unit: z.string().optional(),


### PR DESCRIPTION
# What

Fixes #134.

- Fixes parse logic for `axis` name so it will always match the casing we use internally for planes
- Added a test to ensure we don't break this in the future

# How

-`toLowerCase()` function on `zod` parsing
- Wrote a test to make sure the casing matches our `CartesianPlane` implementation

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   x ] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
