### PR TITLE
chore: Fix Dependabot to work for sub-packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,63 +1,7 @@
 version: 2
 updates:
-    # We need to point to each package.json, so this file will be a bit verbose
-
-    # Root package.json
     - package-ecosystem: 'npm'
       directory: '/'
-      open-pull-requests-limit: 2
-      schedule:
-          interval: 'monthly'
-      reviewers:
-          - 'AllenInstitute/app-dev'
-      commit-message:
-          prefix: 'chore(deps):'
-
-    # Packages
-    - package-ecosystem: 'npm'
-      directory: '/packages/dzi'
-      open-pull-requests-limit: 2
-      schedule:
-          interval: 'monthly'
-      reviewers:
-          - 'AllenInstitute/app-dev'
-      commit-message:
-          prefix: 'chore(deps):'
-
-    - package-ecosystem: 'npm'
-      directory: '/packages/geometry'
-      open-pull-requests-limit: 2
-      schedule:
-          interval: 'monthly'
-      reviewers:
-          - 'AllenInstitute/app-dev'
-      commit-message:
-          prefix: 'chore(deps):'
-    
-    - package-ecosystem: 'npm'
-      directory: '/packages/omezarr'
-      open-pull-requests-limit: 2
-      schedule:
-          interval: 'monthly'
-      reviewers:
-          - 'AllenInstitute/app-dev'
-      commit-message:
-          prefix: 'chore(deps):'
-    
-    - package-ecosystem: 'npm'
-      directory: '/packages/core'
-      open-pull-requests-limit: 2
-      schedule:
-          interval: 'monthly'
-      reviewers:
-          - 'AllenInstitute/app-dev'
-      commit-message:
-          prefix: 'chore(deps):'
-
-    # Examples
-    - package-ecosystem: 'npm'
-      directory: '/examples'
-      open-pull-requests-limit: 2
       schedule:
           interval: 'monthly'
       reviewers:


### PR DESCRIPTION
# What

Went digging and found out that I misconfigured it, you can just use the root and it will search for sub-packages: https://github.com/dependabot/dependabot-core/pull/11487 (See "Proper Configuration" section)

# How

Just set it up for the root

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
