### PR TITLE
feat: DZI fetch function

### DIFF
--- a/packages/dzi/src/index.ts
+++ b/packages/dzi/src/index.ts
@@ -1,4 +1,4 @@
-export { getVisibleTiles, type DziImage, type DziTile } from './loader';
+export { fetchDziMetadata, getVisibleTiles, type DziImage, type DziTile } from './loader';
 export {
     buildDziRenderer,
     buildAsyncDziRenderer,


### PR DESCRIPTION
# What

- A `fetch` helper for DZI image code to simplify getting started with the `vis-dzi` package

# How

- Took `bkp-client` fetch code
- Spruced it up a bit with our `vis` `logger`,
- Made a helper function in `dzi/loader.ts` that is exported

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [ ] Have you tested the application on these browsers?
    -   [ ] Chrome (Fully supported)
    -   [x] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
