### PR TITLE
chore: Update release numbers for release

### DIFF
--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-dzi",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "contributors": [
         {
             "name": "Lane Sawyer",

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-geometry",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "contributors": [
         {
             "name": "Lane Sawyer",

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@alleninstitute/vis-omezarr",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "contributors": [
         {
             "name": "Lane Sawyer",


### PR DESCRIPTION
See release notes for details

`core` was already bumped in the most recent `core` PR

And we don't need to have lockfile changes because `pnpm` doesn't put the version number in them!