### PR TITLE
Added support for Zarr V3

### DIFF
--- a/packages/omezarr/src/zarr/loading.ts
+++ b/packages/omezarr/src/zarr/loading.ts
@@ -98,10 +98,11 @@ async function loadZarrArrayFileFromStore(
  * The object returned from this function can be passed to most of the other utilities for ome-zarr data
  * manipulation.
  */
-export async function loadMetadata(res: WebResource, version = 2, loadV2ArrayAttrs = true): Promise<OmeZarrMetadata> {
+export async function loadMetadata(res: WebResource, loadV2ArrayAttrs = true): Promise<OmeZarrMetadata> {
     const url = getResourceUrl(res);
     const store = new zarr.FetchStore(url);
     const attrs: OmeZarrAttrs = await loadZarrAttrsFileFromStore(store);
+    const version = attrs.zarrVersion;
     const arrays = await Promise.all(
         attrs.multiscales
             .map((multiscale) => {
@@ -318,7 +319,7 @@ export async function loadSlice(
         logger.error(message);
         throw new VisZarrDataError(message);
     }
-    const { raw } = await loadZarrArrayFileFromStore(store, arr.path, 2, false);
+    const { raw } = await loadZarrArrayFileFromStore(store, arr.path, metadata.zarrVersion, false);
     const result = await zarr.get(raw, buildQuery(r, axes, level.shape), { opts: { signal: signal ?? null } });
     if (typeof result === 'number') {
         throw new Error('oh noes, slice came back all weird');

--- a/packages/omezarr/src/zarr/types.ts
+++ b/packages/omezarr/src/zarr/types.ts
@@ -170,12 +170,11 @@ export const OmeZarrAttrsSchema = z.union([
             zarrVersion: 3,
             ...v.ome,
         };
-    } else {
-        return {
-            zarrVersion: 2,
-            ...v,
-        }
     }
+    return {
+        zarrVersion: 2,
+        ...v,
+    };
 });
 
 export type DehydratedOmeZarrArray = {

--- a/packages/omezarr/src/zarr/types.ts
+++ b/packages/omezarr/src/zarr/types.ts
@@ -139,7 +139,7 @@ export const OmeZarrOmeroSchema: z.ZodType<OmeZarrOmero> = z.object({
 export type BaseOmeZarrAttrs = {
     multiscales: OmeZarrMultiscale[];
     omero?: OmeZarrOmero | undefined; // omero is a transitional field, meaning it is expected to go away in a later version
-}
+};
 
 export type OmeZarrAttrsV2 = BaseOmeZarrAttrs;
 
@@ -159,23 +159,23 @@ export const OmeZarrAttrsBaseSchema: z.ZodType<OmeZarrAttrsV2> = z.object({
 export const OmeZarrAttrsV2Schema = OmeZarrAttrsBaseSchema;
 
 export const OmeZarrAttrsV3Schema: z.ZodType<OmeZarrAttrsV3> = z.object({
-    ome: OmeZarrAttrsBaseSchema
+    ome: OmeZarrAttrsBaseSchema,
 });
 
-export const OmeZarrAttrsSchema = z.union([
-    OmeZarrAttrsV2Schema, OmeZarrAttrsV3Schema
-]).transform<OmeZarrAttrs>((v: OmeZarrAttrsV2 | OmeZarrAttrsV3) => {
-    if ('ome' in v) {
+export const OmeZarrAttrsSchema = z
+    .union([OmeZarrAttrsV2Schema, OmeZarrAttrsV3Schema])
+    .transform<OmeZarrAttrs>((v: OmeZarrAttrsV2 | OmeZarrAttrsV3) => {
+        if ('ome' in v) {
+            return {
+                zarrVersion: 3,
+                ...v.ome,
+            };
+        }
         return {
-            zarrVersion: 3,
-            ...v.ome,
+            zarrVersion: 2,
+            ...v,
         };
-    }
-    return {
-        zarrVersion: 2,
-        ...v,
-    };
-});
+    });
 
 export type DehydratedOmeZarrArray = {
     path: string;

--- a/site/src/examples/omezarr/omezarr-demo.tsx
+++ b/site/src/examples/omezarr/omezarr-demo.tsx
@@ -43,6 +43,15 @@ const demoOptions: DemoOption[] = [
             url: 's3://allen-genetic-tools/tissuecyte/823818122/ome_zarr_conversion/823818122.zarr/',
         },
     },
+    {
+        value: 'opt5',
+        label: 'V3 Zarr Example Image (S3) (color channels: [R, G, B])',
+        res: {
+            type: 's3',
+            region: 'us-west-2',
+            url: 's3://h301-scanning-802451596237-us-west-2/2402091625/ome_zarr_conversion/1458501514.zarr/',
+        },
+    },
 ];
 
 const screenSize: vec2 = [800, 800];


### PR DESCRIPTION
# Added support for Zarr V3

## What

Introduces full support for V3 of the Zarr format, specifically as implemented by the OME-Zarr standard.

## How

- Detects the version of the file based on the JSON shape of its metadata
- Loads the Zarr array data using the detected Zarr version

## Testing

**NOTE:** During dev testing, I noticed that at least one example Zarr V3 file didn't load all chunks successfully -- this could be due to network request issues, as most chunks of the file load without issue, just a few typically failing. This issue remained even when using the Priority Cache solution, though that did load more chunks successfully on average. Also, loading time overall for V3 Zarr chunks seems to be significantly slower than it is for non-V3 chunks.

- Open the Ome-Zarr demo page in the docs site
- Enter the following custom URL: `s3://h301-scanning-802451596237-us-west-2/4250627731/ome_zarr_conversion/1453939576.zarr`
- Watch it load!
- Try out a few others; you can find several on PPDC, search Digital Assets for `tags` `contains` `h301-scanning`

## PR Checklist

-   [ ] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [ ] Do the CI checks pass successfully?
-   [ ] Have you smoke tested the example applications?
-   [ ] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [x] Chrome (Fully supported)
    -   [ ] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
