### PR TITLE
chore: Create standalone Priority Cache without fetching

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,4 +20,5 @@ export type {
 export { RenderServer } from './abstract/render-server';
 
 export { Logger, logger } from './logger';
+export { PriorityCache, AsyncPriorityCache, type Cacheable } from './shared-priority-cache/priority-cache';
 export { SharedPriorityCache } from './shared-priority-cache/shared-cache';

--- a/packages/core/src/shared-priority-cache/priority-cache.test.ts
+++ b/packages/core/src/shared-priority-cache/priority-cache.test.ts
@@ -1,7 +1,7 @@
 /** biome-ignore-all lint/suspicious/noConsole: <its tests> */
 import { beforeEach, describe, expect, test } from 'vitest';
-import { PriorityCache, type Resource } from './priority-cache';
-import { FakeStore, PayloadFactory, PromiseFarm } from './test-utils';
+import { AsyncPriorityCache, Cacheable } from './priority-cache';
+import { FakeStore, Payload, PayloadFactory, PromiseFarm } from './test-utils';
 
 let factory = new PayloadFactory();
 
@@ -15,7 +15,7 @@ function setupTestEnv(limit: number, fetchLimit: number) {
     };
     factory = new PayloadFactory();
     const fakeStore: FakeStore = new FakeStore();
-    const cache: PriorityCache = new PriorityCache(fakeStore, () => 0, limit, fetchLimit);
+    const cache: AsyncPriorityCache<Payload> = new AsyncPriorityCache(fakeStore, () => 0, limit, fetchLimit);
     return { cache, resolveFetches, fakeFetchItem, fetchSpies, fakeStore, promises };
 }
 describe('basics', () => {
@@ -35,7 +35,7 @@ describe('basics', () => {
         });
     });
     test('when evicting and fetching, priority is respected', async () => {
-        const score = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7 };
+        const score: Record<string, number> = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7 };
         env = setupTestEnv(5, 1);
         const { cache, resolveFetches, fakeFetchItem } = env;
         const resolveAndRequestNext = async () => {
@@ -86,7 +86,7 @@ describe.skip('throughput', () => {
         const fakeStore: FakeStore = new FakeStore();
         const priorities: Record<string, number> = {};
         let numEvicted = 0;
-        const cache: PriorityCache = new PriorityCache(
+        const cache: AsyncPriorityCache<Cacheable> = new AsyncPriorityCache<Cacheable>(
             fakeStore,
             (item) => {
                 return priorities[item] ?? 0;
@@ -94,7 +94,7 @@ describe.skip('throughput', () => {
             1000,
             20,
         );
-        const newItem = (ID: string): Resource => {
+        const newItem = (ID: string): Cacheable => {
             priorities[ID] = Math.random() * 100;
             return {
                 sizeInBytes: () => 1,
@@ -129,8 +129,8 @@ describe.skip('throughput', () => {
             const priorities: Record<string, number> = {};
             let numEvicted = 0;
             const score = (k: string) => priorities[k] ?? 0;
-            const cache: PriorityCache = new PriorityCache(fakeStore, score, 1000, 20);
-            const newItem = (ID: string): Resource => {
+            const cache: AsyncPriorityCache<Cacheable> = new AsyncPriorityCache<Cacheable>(fakeStore, score, 1000, 20);
+            const newItem = (ID: string): Cacheable => {
                 priorities[ID] = Math.random() * 100;
                 return {
                     sizeInBytes: () => 1,
@@ -180,7 +180,7 @@ describe.skip('throughput', () => {
         factory = new PayloadFactory();
         const priorities: Record<string, number> = {};
         const score = (k: string) => priorities[k] ?? 0;
-        const cache: PriorityCache = new PriorityCache(fakeStore, score, 1000, 20);
+        const cache: AsyncPriorityCache<Cacheable> = new AsyncPriorityCache<Cacheable>(fakeStore, score, 1000, 20);
 
         const onehundo_k = 100_000;
         const begin = performance.now();

--- a/packages/core/src/shared-priority-cache/priority-cache.ts
+++ b/packages/core/src/shared-priority-cache/priority-cache.ts
@@ -31,11 +31,7 @@ export class PriorityCache<T extends Cacheable> {
     private used: number;
 
     // items with lower scores will be evicted before items with high scores
-    constructor(
-        store: Store<CacheKey, T>,
-        score: (k: CacheKey) => number,
-        limitInBytes: number,
-    ) {
+    constructor(store: Store<CacheKey, T>, score: (k: CacheKey) => number, limitInBytes: number) {
         this.store = store;
         this.evictPriority = new MinHeap<CacheKey>(5000, score);
         this.limit = limitInBytes;
@@ -111,13 +107,12 @@ export class PriorityCache<T extends Cacheable> {
     }
 }
 
-
 export class AsyncPriorityCache<T extends Cacheable> extends PriorityCache<T> {
     private fetchPriority: KeyedMinHeap<PendingResource<T>, CacheKey>;
     private pendingFetches: Map<CacheKey, AbortController>;
     private MAX_INFLIGHT_FETCHES: number;
     private notify: undefined | ((k: CacheKey, result: FetchResult) => void);
-    
+
     // items with lower scores will be evicted before items with high scores
     constructor(
         store: Store<CacheKey, T>,
@@ -133,7 +128,7 @@ export class AsyncPriorityCache<T extends Cacheable> extends PriorityCache<T> {
         this.MAX_INFLIGHT_FETCHES = maxFetches;
         this.notify = onDataArrived;
     }
-    
+
     enqueue(key: CacheKey, fetcher: (abort: AbortSignal) => Promise<T>) {
         // enqueue the item, if we dont already have it, or are not already asking
         if (!this.has(key) && !this.pendingFetches.has(key) && !this.fetchPriority.hasItemWithKey(key)) {

--- a/packages/core/src/shared-priority-cache/priority-cache.ts
+++ b/packages/core/src/shared-priority-cache/priority-cache.ts
@@ -2,11 +2,11 @@ import { MinHeap } from './min-heap';
 import { KeyedMinHeap } from './keyed-heap';
 
 type CacheKey = string;
-export interface Resource {
+export interface Cacheable {
     destroy?: () => void;
     sizeInBytes: () => number;
 }
-export interface Store<K extends {}, V extends {}> {
+export interface Store<K extends {}, V> {
     set(k: K, v: V): void;
     get(k: K): V | undefined;
     has(k: K): boolean;
@@ -14,45 +14,37 @@ export interface Store<K extends {}, V extends {}> {
     keys(): Iterable<K>;
     values(): Iterable<V>;
 }
-type PendingResource = {
+type PendingResource<T extends Cacheable> = {
     key: CacheKey;
-    fetch: (sig: AbortSignal) => Promise<Resource>;
+    fetch: (sig: AbortSignal) => Promise<T>;
 };
 
 function negate(fn: (k: CacheKey) => number) {
     return (k: CacheKey) => -fn(k);
 }
 export type FetchResult = { status: 'success' } | { status: 'failure'; reason: unknown };
-export class PriorityCache {
-    private store: Store<CacheKey, Resource>;
+
+export class PriorityCache<T extends Cacheable> {
+    private store: Store<CacheKey, T>;
     private evictPriority: MinHeap<CacheKey>;
-    private fetchPriority: KeyedMinHeap<PendingResource, CacheKey>;
-    private pendingFetches: Map<CacheKey, AbortController>;
     private limit: number;
     private used: number;
-    private MAX_INFLIGHT_FETCHES: number;
-    private notify: undefined | ((k: CacheKey, result: FetchResult) => void);
+
     // items with lower scores will be evicted before items with high scores
     constructor(
-        store: Store<CacheKey, Resource>,
+        store: Store<CacheKey, T>,
         score: (k: CacheKey) => number,
         limitInBytes: number,
-        maxFetches: number,
-        onDataArrived?: (key: CacheKey, result: FetchResult) => void,
     ) {
         this.store = store;
         this.evictPriority = new MinHeap<CacheKey>(5000, score);
-        this.fetchPriority = new KeyedMinHeap<PendingResource, CacheKey>(5000, negate(score), (pr) => pr.key);
         this.limit = limitInBytes;
-        this.pendingFetches = new Map();
         this.used = 0;
-        this.MAX_INFLIGHT_FETCHES = maxFetches;
-        this.notify = onDataArrived;
     }
     // add {key:item} to the cache - return false (and fail) if the key is already present
     // may evict items to make room
     // return true on success
-    put(key: CacheKey, item: Resource): boolean {
+    put(key: CacheKey, item: T): boolean {
         if (this.store.has(key)) {
             return false;
         }
@@ -65,12 +57,84 @@ export class PriorityCache {
         this.used += size;
         return true;
     }
-    private sanitizedSize(item: Resource) {
+    private sanitizedSize(item: T) {
         const givenSize = item.sizeInBytes?.() ?? 0;
         const size = Number.isFinite(givenSize) ? Math.max(0, givenSize) : 0;
         return size;
     }
-    enqueue(key: CacheKey, fetcher: (abort: AbortSignal) => Promise<Resource>) {
+
+    // it is expected that the score function is not "pure" -
+    // it has a closure over data that changes over time, representing changing priorities
+    // thus - the owner of this cache has a responsibility to notify the cache when significant
+    // changes in priority occur!
+    reprioritize(score: (k: CacheKey) => number) {
+        this.evictPriority.rebuild(score);
+    }
+
+    get(key: CacheKey): T | undefined {
+        return this.store.get(key);
+    }
+
+    has(key: CacheKey): boolean {
+        return this.store.has(key);
+    }
+
+    cached(key: CacheKey): boolean {
+        return this.store.has(key);
+    }
+
+    isFull(): boolean {
+        return this.used >= this.limit;
+    }
+
+    private evictLowestPriority() {
+        const evictMe = this.evictPriority.popMinItem();
+        if (evictMe === null) return false;
+
+        const data = this.store.get(evictMe);
+        if (data) {
+            data.destroy?.();
+            this.store.delete(evictMe);
+            const size = this.sanitizedSize(data);
+            this.used -= size;
+        }
+        return true;
+    }
+
+    private evictUntil(targetUsedBytes: number) {
+        while (this.used > targetUsedBytes) {
+            if (!this.evictLowestPriority()) {
+                // note: evictLowestPriority mutates this.used
+                return; // all items evicted...
+            }
+        }
+    }
+}
+
+
+export class AsyncPriorityCache<T extends Cacheable> extends PriorityCache<T> {
+    private fetchPriority: KeyedMinHeap<PendingResource<T>, CacheKey>;
+    private pendingFetches: Map<CacheKey, AbortController>;
+    private MAX_INFLIGHT_FETCHES: number;
+    private notify: undefined | ((k: CacheKey, result: FetchResult) => void);
+    
+    // items with lower scores will be evicted before items with high scores
+    constructor(
+        store: Store<CacheKey, T>,
+        score: (k: CacheKey) => number,
+        limitInBytes: number,
+        maxFetches: number,
+        onDataArrived?: (key: CacheKey, result: FetchResult) => void,
+    ) {
+        super(store, score, limitInBytes);
+
+        this.fetchPriority = new KeyedMinHeap<PendingResource<T>, CacheKey>(5000, negate(score), (pr) => pr.key);
+        this.pendingFetches = new Map();
+        this.MAX_INFLIGHT_FETCHES = maxFetches;
+        this.notify = onDataArrived;
+    }
+    
+    enqueue(key: CacheKey, fetcher: (abort: AbortSignal) => Promise<T>) {
         // enqueue the item, if we dont already have it, or are not already asking
         if (!this.has(key) && !this.pendingFetches.has(key) && !this.fetchPriority.hasItemWithKey(key)) {
             this.fetchPriority.addItem({ key, fetch: fetcher });
@@ -79,7 +143,8 @@ export class PriorityCache {
         }
         return false;
     }
-    private beginFetch({ key, fetch }: PendingResource) {
+
+    private beginFetch({ key, fetch }: PendingResource<T>) {
         const abort = new AbortController();
         this.pendingFetches.set(key, abort);
         return fetch(abort.signal)
@@ -95,6 +160,7 @@ export class PriorityCache {
                 this.fetchToLimit();
             });
     }
+
     private fetchToLimit() {
         let toFetch = Math.max(0, this.MAX_INFLIGHT_FETCHES - this.pendingFetches.size);
         for (let i = 0; i < toFetch; i++) {
@@ -116,8 +182,8 @@ export class PriorityCache {
     // it has a closure over data that changes over time, representing changing priorities
     // thus - the owner of this cache has a responsibility to notify the cache when significant
     // changes in priority occur!
-    reprioritize(score: (k: CacheKey) => number) {
-        this.evictPriority.rebuild(score);
+    override reprioritize(score: (k: CacheKey) => number) {
+        super.reprioritize(score);
         this.fetchPriority.rebuild(negate(score));
         for (const [key, abort] of this.pendingFetches) {
             if (score(key) === 0) {
@@ -126,38 +192,8 @@ export class PriorityCache {
             }
         }
     }
-    get(key: CacheKey): Resource | undefined {
-        return this.store.get(key);
-    }
 
-    has(key: CacheKey): boolean {
-        return this.store.has(key);
-    }
     cachedOrPending(key: CacheKey): boolean {
-        return this.store.has(key) || this.fetchPriority.hasItemWithKey(key) || this.pendingFetches.has(key);
-    }
-    isFull(): boolean {
-        return this.used >= this.limit;
-    }
-    private evictLowestPriority() {
-        const evictMe = this.evictPriority.popMinItem();
-        if (evictMe === null) return false;
-
-        const data = this.store.get(evictMe);
-        if (data) {
-            data.destroy?.();
-            this.store.delete(evictMe);
-            const size = this.sanitizedSize(data);
-            this.used -= size;
-        }
-        return true;
-    }
-    private evictUntil(targetUsedBytes: number) {
-        while (this.used > targetUsedBytes) {
-            if (!this.evictLowestPriority()) {
-                // note: evictLowestPriority mutates this.used
-                return; // all items evicted...
-            }
-        }
+        return this.cached(key) || this.fetchPriority.hasItemWithKey(key) || this.pendingFetches.has(key);
     }
 }

--- a/packages/core/src/shared-priority-cache/test-utils.ts
+++ b/packages/core/src/shared-priority-cache/test-utils.ts
@@ -1,4 +1,4 @@
-import type { Resource, Store } from './priority-cache';
+import type { Cacheable, Store } from './priority-cache';
 import { uniqueId } from 'lodash';
 
 export class PayloadFactory {
@@ -22,7 +22,7 @@ export class PayloadFactory {
     }
 }
 
-export class Payload implements Resource {
+export class Payload implements Cacheable {
     data: number;
     id: string;
     private factory: PayloadFactory;

--- a/packages/core/src/shared-priority-cache/utils.ts
+++ b/packages/core/src/shared-priority-cache/utils.ts
@@ -1,9 +1,9 @@
-import type { Resource } from './priority-cache';
+import type { Cacheable } from './priority-cache';
 import type { ClientSpec } from './shared-cache';
 
 // some utils for tracking changing priorities in our priority cache
 
-export function prioritizeCacheKeys<Item, ItemContent extends Record<string, Resource>>(
+export function prioritizeCacheKeys<Item, ItemContent extends Record<string, Cacheable>>(
     spec: ClientSpec<Item, ItemContent>,
     items: Iterable<Item>,
     priority: 1 | 2,

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -48,9 +48,10 @@
         "registry": "https://npm.pkg.github.com/AllenInstitute"
     },
     "dependencies": {
-        "@alleninstitute/vis-geometry": "workspace:*",
         "@alleninstitute/vis-core": "workspace:*",
+        "@alleninstitute/vis-geometry": "workspace:*",
         "regl": "2.1.0",
+        "uuid": "13.0.0",
         "zarrita": "0.5.3",
         "zod": "4.1.5"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       regl:
         specifier: 2.1.0
         version: 2.1.0
+      uuid:
+        specifier: 13.0.0
+        version: 13.0.0
       zarrita:
         specifier: 0.5.3
         version: 0.5.3
@@ -4117,6 +4120,10 @@ packages:
   utility-types@3.11.0:
     resolution: {integrity: sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==}
     engines: {node: '>= 4'}
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
 
   uzip-module@1.0.3:
     resolution: {integrity: sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==}
@@ -9239,6 +9246,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   utility-types@3.11.0: {}
+
+  uuid@13.0.0: {}
 
   uzip-module@1.0.3: {}
 

--- a/site/src/examples/omezarr/render-utils.ts
+++ b/site/src/examples/omezarr/render-utils.ts
@@ -1,4 +1,4 @@
-import type { SharedPriorityCache, CachedTexture, Resource } from '@alleninstitute/vis-core';
+import type { SharedPriorityCache, CachedTexture, Cacheable } from '@alleninstitute/vis-core';
 import type { vec2 } from '@alleninstitute/vis-geometry';
 import {
     buildOmeZarrSliceRenderer,
@@ -9,7 +9,7 @@ import {
 } from '@alleninstitute/vis-omezarr';
 import type REGL from 'regl';
 
-class Tex implements Resource {
+class Tex implements Cacheable {
     texture: CachedTexture;
     constructor(tx: CachedTexture) {
         this.texture = tx;
@@ -65,7 +65,7 @@ export function buildConnectedRenderer(
         },
         isValue: (v): v is Record<string, Tex> =>
             renderer.isPrepared(
-                mapValues(v, (tx: Resource | undefined) => (tx && tx instanceof Tex ? tx.texture : undefined)),
+                mapValues(v, (tx: Cacheable | undefined) => (tx && tx instanceof Tex ? tx.texture : undefined)),
             ),
         onDataArrived: onData,
     });


### PR DESCRIPTION
# chore: Create standalone Priority Cache without fetching

# What

In order to support alternative use cases that need a prioritized cache implementation without a built-in fetching capability, this PR creates separate `PriorityCache` and `AsyncPriorityCache` classes, with the former having no fetching behavior, and the latter having the existing fetching behavior.

# How

- Created a subclass of `PriorityCache`, named `AsyncPriorityCache` (name very much open to discussion!)
- Moved all fetch-related behaviors from `PriorityCache` to `AsyncPriorityCache`
- Renamed `Resource` to `Cacheable` in order to reduce the implied "web-ishness" of the name of that interface, since theoretically any kind of data can be put into a `PriorityCache`.

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [ ] Do the CI checks pass successfully?
-   [ ] Have you smoke tested the example applications?
-   [ ] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [x] Chrome (Fully supported)
    -   [ ] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
