### PR TITLE
chore: Adding "type: module" to all packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "main": "dist/main.js",
     "module": "dist/module.js",
     "types": "dist/types.d.ts",
+    "type": "module",
     "files": [
         "dist"
     ],

--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -28,6 +28,7 @@
     "main": "dist/main.js",
     "module": "dist/module.js",
     "types": "dist/types.d.ts",
+    "type": "module",
     "files": [
         "dist"
     ],

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -32,6 +32,7 @@
     "main": "dist/main.js",
     "module": "dist/module.js",
     "types": "dist/types.d.ts",
+    "type": "module",
     "files": [
         "dist"
     ],

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -28,6 +28,7 @@
     "main": "dist/main.js",
     "module": "dist/module.js",
     "types": "dist/types.d.ts",
+    "type": "module",
     "files": [
         "dist"
     ],


### PR DESCRIPTION
# chore: Adding "type: module" to all packages

# What

Sets up all of the Vis packages as ES modules.

# How

Added `"type": "module"` to the package.json files of `core`, `dzi`, `geometry`, and `omezarr`. `site` was already setup as an ES module.

# PR Checklist

-   [x] Is your PR title following our conventional commit naming recommendations?
-   [x] Have you filled in the PR Description Template?
-   [x] Is your branch up to date with the latest in `main`?
-   [x] Do the CI checks pass successfully?
-   [x] Have you smoke tested the example applications?
-   [x] Did you check that the changes meet accessibility standards?
-   [x] Have you tested the application on these browsers?
    -   [x] Chrome (Fully supported)
    -   [ ] Firefox (Major bug fixes supported)
    -   [ ] Safari (Major bug fixes supported)
