### PR TITLE
chore: Remove packageManager since Volta manages the proper version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,5 @@
     "volta": {
         "node": "24.15.0",
         "pnpm": "10.33.0"
-    },
-    "packageManager": "pnpm@10.33.0"
+    }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -60,6 +60,5 @@
         "lodash": "4.18.1",
         "regl": "2.1.1",
         "uuid": "13.0.0"
-    },
-    "packageManager": "pnpm@9.14.2"
+    }
 }

--- a/packages/dzi/package.json
+++ b/packages/dzi/package.json
@@ -52,6 +52,5 @@
         "@alleninstitute/vis-geometry": "workspace:*",
         "@alleninstitute/vis-core": "workspace:*",
         "regl": "2.1.1"
-    },
-    "packageManager": "pnpm@9.14.2"
+    }
 }

--- a/packages/geometry/package.json
+++ b/packages/geometry/package.json
@@ -51,6 +51,5 @@
     "publishConfig": {
         "registry": "https://registry.npmjs.org",
         "access": "public"
-    },
-    "packageManager": "pnpm@9.14.2"
+    }
 }

--- a/packages/omezarr/package.json
+++ b/packages/omezarr/package.json
@@ -54,6 +54,5 @@
         "regl": "2.1.1",
         "zarrita": "0.6.1",
         "zod": "4.3.6"
-    },
-    "packageManager": "pnpm@9.14.2"
+    }
 }

--- a/packages/scatterbrain/package.json
+++ b/packages/scatterbrain/package.json
@@ -61,7 +61,6 @@
         "registry": "https://registry.npmjs.org",
         "access": "public"
     },
-    "packageManager": "pnpm@9.14.2",
     "devDependencies": {
         "@types/lodash": "4.17.24"
     }

--- a/site/package.json
+++ b/site/package.json
@@ -67,6 +67,5 @@
         "regl": "2.1.1",
         "sharp": "0.34.5",
         "zarrita": "0.5.1"
-    },
-    "packageManager": "pnpm@9.14.2"
+    }
 }


### PR DESCRIPTION
# What

Removes the Corepack `packageManager` from our `package.json`. Since we're using Volta, it's redundant. And one more thing to try to keep in sync (it's out of date, we are now on v10 of `pnpm`!)

# How

Delete it!

# PR Checklist

- [x] Is your PR title following our conventional commit naming recommendations?
- [x] Have you filled in the PR Description Template?
- [x] Is your branch up to date with the latest in `main`?
- [x] Do the CI checks pass successfully?
- [x] Have you smoke tested the example applications?
- [x] Did you check that the changes meet accessibility standards?
- [ ] Have you tested the application on these browsers?
    - [ ] Chrome (Fully supported)
    - [x] Firefox (Major bug fixes supported)
    - [ ] Safari (Major bug fixes supported)
