### PR TITLE
feat(geometry): add box parameter helper

### DIFF
--- a/packages/geometry/src/BoundingBox.ts
+++ b/packages/geometry/src/BoundingBox.ts
@@ -83,6 +83,9 @@ export function BoxClassFactory<V extends VectorConstraint>(lib: VectorLib<V>) {
 
     const toFlatArray = (box: box<V>) => [...box.minCorner, ...box.maxCorner] as const;
     const size = (b: box<V>) => lib.sub(b.maxCorner, b.minCorner);
+    // return the normalized coordinates of a point within a box, where minCorner maps to all 0s
+    // and maxCorner maps to all 1s. This is the inverse of mixing between the corners of the box.
+    const parameter = (b: box<V>, p: V) => lib.div(lib.sub(p, b.minCorner), size(b));
     const midpoint = (b: box<V>) => lib.scale(lib.add(b.minCorner, b.maxCorner), 0.5);
     const map = (box: box<V>, fn: (v: V) => V) => ({
         minCorner: fn(box.minCorner),
@@ -99,6 +102,7 @@ export function BoxClassFactory<V extends VectorConstraint>(lib: VectorLib<V>) {
         intersection, // return the intersection of two boxes if it exists
         containsPoint, // return true if a point is in a box - note that this is exclusive on the low side, and inclusive on the high side
         size, // how big is it?
+        parameter, // return the normalized [0..1] coordinates of a point within the box (inverse of mix between corners)
         midpoint, // yup you guessed it, return a vector at the center of a box.
         toFlatArray,
         scale,

--- a/packages/geometry/src/tests/box2D.test.ts
+++ b/packages/geometry/src/tests/box2D.test.ts
@@ -82,6 +82,17 @@ describe('box2D', () => {
         expect(size).toStrictEqual([2, 2]);
     });
 
+    test('parameter', () => {
+        // minCorner maps to [0, 0]
+        expect(Box2D.parameter(box, [1, 2])).toStrictEqual([0, 0]);
+        // maxCorner maps to [1, 1]
+        expect(Box2D.parameter(box, [3, 4])).toStrictEqual([1, 1]);
+        // midpoint maps to [0.5, 0.5]
+        expect(Box2D.parameter(box, [2, 3])).toStrictEqual([0.5, 0.5]);
+        // points outside the box are not clamped
+        expect(Box2D.parameter(box, [5, 6])).toStrictEqual([2, 2]);
+    });
+
     test('midpoint', () => {
         const midpoint = Box2D.midpoint(box);
         expect(midpoint).toStrictEqual([2, 3]);

--- a/packages/geometry/src/tests/box3D.test.ts
+++ b/packages/geometry/src/tests/box3D.test.ts
@@ -90,6 +90,17 @@ describe('Box3D', () => {
         expect(size).toStrictEqual([2, 2, 2]);
     });
 
+    test('parameter', () => {
+        // minCorner maps to [0, 0, 0]
+        expect(Box3D.parameter(box, [1, 2, 3])).toStrictEqual([0, 0, 0]);
+        // maxCorner maps to [1, 1, 1]
+        expect(Box3D.parameter(box, [3, 4, 5])).toStrictEqual([1, 1, 1]);
+        // midpoint maps to [0.5, 0.5, 0.5]
+        expect(Box3D.parameter(box, [2, 3, 4])).toStrictEqual([0.5, 0.5, 0.5]);
+        // points outside the box are not clamped
+        expect(Box3D.parameter(box, [5, 6, 7])).toStrictEqual([2, 2, 2]);
+    });
+
     test('midpoint', () => {
         const midpoint = Box3D.midpoint(box);
         expect(midpoint).toStrictEqual([2, 3, 4]);


### PR DESCRIPTION
# What

Adds a generic `parameter` helper to the geometry box library, available on both `Box2D` and `Box3D`. It returns the normalized `[0..1]` coordinates of a point within a box (the inverse of mixing between corners), replacing a local helper that was flagged with a `// todo move me to box library` in a downstream project.

# How

- Added `parameter(box, p) => (p - minCorner) / size` to `BoxClassFactory` in `BoundingBox.ts`, so all box types inherit it.
- Exported it from the factory with a doc comment tying it to `mix`.
- Added unit tests covering minCorner → 0, maxCorner → 1, midpoint → 0.5, and unclamped out-of-box points, for both `box2D.test.ts` and `box3D.test.ts`.

# PR Checklist

- [x] Is your PR title following our conventional commit naming recommendations?
- [x] Have you filled in the PR Description Template?
- [x] Is your branch up to date with the latest in `main`?
- [x] Do the CI checks pass successfully?
- [ ] Have you smoke tested the example applications?
- [ ] Did you check that the changes meet accessibility standards?
