### PR TITLE
ci(release): use vis-prefixed tag for git-cliff bumped version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,13 +45,16 @@ jobs:
             - name: Get bumped version
               run: |
                   PKG="${{ inputs.package }}"
-                  FULL_TAG=$(pnpm exec git-cliff \
+                  CLIFF_TAG=$(pnpm exec git-cliff \
                       --tag-pattern "@alleninstitute/vis-${PKG}@*" \
                       --include-path "packages/${PKG}/**" \
-                      --bumped-version 2>/dev/null)
+                      --bumped-version)
+
+                  VERSION="${CLIFF_TAG##*@}"
+                  FULL_TAG="@alleninstitute/vis-${PKG}@${VERSION}"
 
                   if [[ ! "$FULL_TAG" =~ ^@alleninstitute/vis-[^@]+@[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-                      echo "::error::Unexpected git-cliff output: '${FULL_TAG}'"
+                      echo "::error::Computed tag '${FULL_TAG}' does not match expected format '@alleninstitute/vis-${PKG}@<semver>' (git-cliff output: '${CLIFF_TAG}')"
                       exit 1
                   fi
                   if git rev-parse "$FULL_TAG" >/dev/null 2>&1; then


### PR DESCRIPTION
# What

Fix the `Release` workflow so the `geometry` (and every other) package release produces and validates the correct `@alleninstitute/vis-<pkg>@<version>` tag format. Previously git-cliff returned a wrongly-prefixed tag (e.g. `@alleninstitute/geometry@0.1.0`), causing the release to fail.

# How

In the **Get bumped version** step of `.github/workflows/release.yml`:

- Keep `git-cliff --bumped-version` as the source of the next version number, but extract only the semver from its output and reconstruct the tag as `@alleninstitute/vis-${PKG}@${VERSION}`.
- Fail with a clear error that reports both the computed tag and the raw git-cliff output when the result does not match `@alleninstitute/vis-<pkg>@<semver>`.
- Remove the `2>/dev/null` stderr suppression so future git-cliff failures are visible in the logs.

# PR Checklist

- [x] Is your PR title following our conventional commit naming recommendations?
- [x] Have you filled in the PR Description Template?
- [x] Is your branch up to date with the latest in `main`?
- [x] Do the CI checks pass successfully?
- [ ] Have you smoke tested the example applications?
- [ ] Did you check that the changes meet accessibility standards?
- [ ] Have you tested the application on these browsers?
    - [ ] Chrome (Fully supported)
    - [ ] Firefox (Major bug fixes supported)
    - [ ] Safari (Major bug fixes supported)
