### PR TITLE
ci(release): match git-cliff vis- stripped tag in bump pattern

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,13 @@ jobs:
             - name: Get bumped version
               run: |
                   PKG="${{ inputs.package }}"
+                  # git-cliff strips the "vis-" prefix when it formats the bumped
+                  # tag, then rejects its own output against --tag-pattern. The
+                  # optional "(vis-)?" group matches the real tags (so the base
+                  # version is detected) AND git-cliff's stripped output (so it
+                  # does not error). We rebuild the canonical tag from the semver.
                   CLIFF_TAG=$(pnpm exec git-cliff \
-                      --tag-pattern "@alleninstitute/vis-${PKG}@*" \
+                      --tag-pattern "@alleninstitute/(vis-)?${PKG}@" \
                       --include-path "packages/${PKG}/**" \
                       --bumped-version)
 


### PR DESCRIPTION
# What

Follow-up to #268. The `Release` workflow still failed when run from `main`: the **Get bumped version** step crashed with exit 1 before producing any output, e.g. for `geometry`:

```
ERROR git_cliff > Changelog error: `Next version (@alleninstitute/geometry@0.1.0) does not match the tag pattern: @alleninstitute/vis-geometry@*`
```

# How

git-cliff strips the `vis-` prefix when it formats the bumped tag (it renders the existing `@alleninstitute/vis-geometry@*` tags as `@alleninstitute/geometry@*` internally), then rejects its own output against the strict `--tag-pattern`, so `--bumped-version` exits non-zero before printing anything — the canonical-tag reconstruction added in #268 never got a chance to run.

The fix makes `--tag-pattern` use an optional `(vis-)?` group: `@alleninstitute/(vis-)?${PKG}@`. This matches:

- the **real** git tags (which contain `vis-`) so the base version is still detected and bumped correctly, and
- git-cliff's **stripped** output so its internal validation passes and it exits 0.

The workflow still rebuilds the canonical `@alleninstitute/vis-<pkg>@<semver>` tag from the returned semver and validates the format. Verified locally for all packages:

| package | git-cliff output | rebuilt tag |
| --- | --- | --- |
| core | `@alleninstitute/core@0.1.0` | `@alleninstitute/vis-core@0.1.0` |
| dzi | `@alleninstitute/dzi@0.1.0` | `@alleninstitute/vis-dzi@0.1.0` |
| geometry | `@alleninstitute/geometry@0.1.0` | `@alleninstitute/vis-geometry@0.1.0` |
| omezarr | `@alleninstitute/omezarr@0.1.0` | `@alleninstitute/vis-omezarr@0.1.0` |
| scatterbrain | `@alleninstitute/vis-scatterbrain@0.1.1` | `@alleninstitute/vis-scatterbrain@0.1.1` |

(scatterbrain shows git-cliff doesn't always strip `vis-`, which is why the group is optional.)

# PR Checklist

- [x] Is your PR title following our conventional commit naming recommendations?
- [x] Have you filled in the PR Description Template?
- [ ] Is your branch up to date with the latest in `main`?
- [ ] Do the CI checks pass successfully?
- [ ] Have you smoke tested the example applications?
- [ ] Did you check that the changes meet accessibility standards?
- [ ] Have you tested the application on these browsers?
    - [ ] Chrome (Fully supported)
    - [ ] Firefox (Major bug fixes supported)
    - [ ] Safari (Major bug fixes supported)
