### PR TITLE
ci(publish): use pnpm publish to resolve workspace deps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,4 +49,4 @@ jobs:
 
             - name: Publish
               working-directory: ${{ steps.pkg.outputs.pkg_dir }}
-              run: npm publish --access public --provenance
+              run: pnpm publish --access public --provenance --no-git-checks


### PR DESCRIPTION
# What

Fixes the npm publishing flow so inter-package `workspace:*` dependencies are resolved to real version numbers when publishing. Previously published packages (e.g. `@alleninstitute/vis-omezarr@0.1.0`/`0.1.1`) shipped with literal `workspace:*` specifiers and were uninstallable.

# How

Switches the publish step in `publish.yml` from `npm publish` to `pnpm publish`. `npm publish` does not understand pnpm's `workspace:` protocol and leaves `"@alleninstitute/vis-core": "workspace:*"` verbatim in the published `package.json`. `pnpm publish` rewrites those specifiers to the resolved versions (e.g. `0.0.7`) at pack time.

Also adds `--no-git-checks`: the workflow is triggered by a tag push, which `actions/checkout` resolves to a detached HEAD. Without the flag, pnpm's default publish-branch check fails because HEAD is not on `main`.

**Verified locally** via `pnpm pack` — the tarball's `package.json` now contains resolved versions:

```
"@alleninstitute/vis-core": "0.0.7"      (was workspace:*)
"@alleninstitute/vis-geometry": "0.0.9"  (was workspace:*)
```

Note: already-published `vis-omezarr@0.1.0`/`0.1.1` remain broken on npm; a fresh version (`0.1.2`, already bumped in-tree) published via the corrected workflow will produce a clean tarball.

# PR Checklist

- [x] Is your PR title following our conventional commit naming recommendations?
- [x] Have you filled in the PR Description Template?
- [x] Is your branch up to date with the latest in `main`?
- [ ] Do the CI checks pass successfully?
- [ ] Have you smoke tested the example applications?
- [ ] Did you check that the changes meet accessibility standards?
