### PR TITLE
Noah/refactor filtering

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,4 +25,4 @@ export {
 export { WorkerPool, type WorkerInit } from './workers/worker-pool';
 
 export * from './rendering/webgpu';
-export { given, FilterTable } from './rendering/webgpu/filter/query';
+export { given } from './rendering/webgpu/filter/query';

--- a/packages/core/src/rendering/webgpu/filter/build.ts
+++ b/packages/core/src/rendering/webgpu/filter/build.ts
@@ -1,4 +1,4 @@
-import * as wgh from 'webgpu-utils';
+import * as wgh from 'webgpu-utils'
 // assuming we generated a shader, can we build a pipeline?
 export function buildFilterPipeline(dev: GPUDevice, code: string, entryPoint: string, label: string) {
     const module = dev.createShaderModule({
@@ -6,23 +6,23 @@ export function buildFilterPipeline(dev: GPUDevice, code: string, entryPoint: st
         label,
     });
 
-    const defs = wgh.makeShaderDataDefinitions(code);
+    const defs = wgh.makeShaderDataDefinitions(code)
     const desc: wgh.PipelineDescriptor = {
         compute: {
             entryPoint,
-        },
+        }
     };
     const layouts = wgh.makeBindGroupLayoutDescriptors(defs, desc);
     const pipeLayout: GPUPipelineLayout = dev.createPipelineLayout({
-        bindGroupLayouts: layouts.map((d) => dev.createBindGroupLayout(d)),
-    });
+        bindGroupLayouts: layouts.map((d)=>dev.createBindGroupLayout(d))
+    })
     const pipeline = dev.createComputePipeline({
         label,
         compute: {
             module,
-            entryPoint,
+            entryPoint
         },
-        layout: pipeLayout,
+        layout: pipeLayout
     });
-    return { defs, pipeline };
+    return { defs, pipeline }
 }

--- a/packages/core/src/rendering/webgpu/filter/build.ts
+++ b/packages/core/src/rendering/webgpu/filter/build.ts
@@ -1,4 +1,4 @@
-import * as wgh from 'webgpu-utils'
+import * as wgh from 'webgpu-utils';
 // assuming we generated a shader, can we build a pipeline?
 export function buildFilterPipeline(dev: GPUDevice, code: string, entryPoint: string, label: string) {
     const module = dev.createShaderModule({
@@ -6,23 +6,23 @@ export function buildFilterPipeline(dev: GPUDevice, code: string, entryPoint: st
         label,
     });
 
-    const defs = wgh.makeShaderDataDefinitions(code)
+    const defs = wgh.makeShaderDataDefinitions(code);
     const desc: wgh.PipelineDescriptor = {
         compute: {
             entryPoint,
-        }
+        },
     };
     const layouts = wgh.makeBindGroupLayoutDescriptors(defs, desc);
     const pipeLayout: GPUPipelineLayout = dev.createPipelineLayout({
-        bindGroupLayouts: layouts.map((d)=>dev.createBindGroupLayout(d))
-    })
+        bindGroupLayouts: layouts.map((d) => dev.createBindGroupLayout(d)),
+    });
     const pipeline = dev.createComputePipeline({
         label,
         compute: {
             module,
-            entryPoint
+            entryPoint,
         },
-        layout: pipeLayout
+        layout: pipeLayout,
     });
-    return { defs, pipeline }
+    return { defs, pipeline };
 }

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -1,6 +1,6 @@
 import { type WgslType, type Sel, type Tables } from './types';
 
-const entries = (r: object)=> Object.entries(r);
+const entries = (r: object) => Object.entries(r);
 
 function generateOutputStructure(selections: ReadonlyArray<Sel>) {
     // the names of the values in the structure dont matter at all -

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -6,26 +6,26 @@ function generateOutputStructure(selections: ReadonlyArray<Sel>) {
     // the names of the values in the structure dont matter at all -
     const structName = `OutputStruct`;
     const fields = selections.map((s, i) => `field_${i.toFixed(0)}: ${s.type},`).join('\n');
-    const decl = `struct ${structName} {\n ${fields} \n };`;
+    const structDecl = `struct ${structName} {\n ${fields} \n };`;
     const initializers = selections.map((s) => s.selection).join(', ');
     const construct = `${structName}(${initializers})`;
 
-    return { structName, decl, construct };
+    return { structName,  structDecl, construct };
 }
 export function generateShader(params: {
     workgroupSize: number;
     inputBindings: string;
     predicateExpr: string;
-    uniformStruct: { name: string; typeName: string; decl: string };
+    uniformStruct: { name: string; typeName: string; structDecl: string };
     indexed: boolean;
     selections: ReadonlyArray<Sel>;
 }) {
     const { inputBindings, predicateExpr, uniformStruct, selections, workgroupSize, indexed } = params;
-    const { structName, decl, construct } = generateOutputStructure(selections);
+    const { structName, structDecl, construct } = generateOutputStructure(selections);
     const host = /*wgsl*/ `
 
-    ${uniformStruct.decl}
-    ${decl}
+    ${uniformStruct.structDecl}
+    ${structDecl}
     var<workgroup> results: array<u32,${workgroupSize}>;
     var<workgroup> count: atomic<u32>;
 
@@ -129,7 +129,7 @@ export function assembleQuery<Ts extends Tables>(
             predicateExpr: predExpr,
             indexed,
             selections: ctx.selections.map((s) => ({ selection: s.selection, type: s.type })),
-            uniformStruct: { name: ctx.uniformName, typeName: ctx.uniformTypeName, decl: uniStructDecl },
+            uniformStruct: { name: ctx.uniformName, typeName: ctx.uniformTypeName, structDecl: uniStructDecl },
         }),
         bindingLookups,
     };

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -1,5 +1,9 @@
 import { type WgslType, type Sel, type Tables } from './types';
+
+// lodash is being really troublesome.. so I wrote my own here
+/* oxlint-disable no-console, typescript/no-explicit-any*/
 const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
+
 function generateOutputStructure(selections: ReadonlyArray<Sel>) {
     // the names of the values in the structure dont matter at all -
     const structName = `OutputStruct`;

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -1,179 +1,34 @@
-// generate the interesting bits of the filter-shader
-
 import {
-    type Elem,
-    type FilterShaderQueryContext,
     type WgslType,
-    type ITable,
-    type OP,
-    type PredLst,
     type Sel,
-    type SimplePredExpr,
     type Tables,
-    type VOP,
 } from './types';
-
-function isVecOp(s: OP | VOP): s is VOP {
-    return s.startsWith('a');
-}
-function parseVecOp(op: VOP) {
-    const aggregation = op.substring(0, 3);
-    const sop = op.substring(4).split(')')[0];
-    return [aggregation, sop] as ['any' | 'all', OP];
-}
-
-// dont export this - its only legit if we know a bunch of stuff about the string
-function fieldType(s: string, table: ITable) {
-    return table[s];
-}
-export function indexExprType(s: string, tables: Tables, from: string) {
-    const ext = looksLikeIndexExpr(s, tables, from);
-    return ext ? ext.type : undefined;
-}
-export function looksLikeIndexExpr(s: string, tables: Tables, from: string) {
-    // the goal here is to parse an expr that looks like:
-    // someTable[someColumn].someOtherColumn
-    // could I have used Regex? yes, and perhaps that would be more elegant!
-    // for now, this works, and its not too long
-
-    const [tbl, rest] = s.split('[');
-    if (tbl && rest) {
-        const [index_field, selection] = rest.split('].');
-        if (index_field && selection) {
-            if (tables[tbl] && tables[from] && tables[from][index_field] && tables[tbl][selection]) {
-                // return the expected type
-                return {
-                    fTable: tbl,
-                    selection,
-                    index_field,
-                    from,
-                    type: tables[tbl][selection],
-                };
-            }
-        }
-    }
-    return false;
-}
-function genRef(ctx: FilterShaderQueryContext<Tables>, operand: string, indexing: string = 'element') {
-    if (operand === '$index') {
-        return indexing;
-    }
-    const indexed = looksLikeIndexExpr(operand, ctx.tables, ctx.from);
-    if (indexed) {
-        return `${indexed.fTable}_${indexed.selection}[${indexed.from}_${indexed.index_field}[${indexing}]]`;
-    } else if (operand in ctx.tables[ctx.from]!) {
-        return `${ctx.from}_${operand}[${indexing}]`;
-    }
-    return operand;
-}
-function genPred(ctx: FilterShaderQueryContext<Tables>, p: SimplePredExpr) {
-    const [lhs, op, rhs] = p.split(' ') as [string, OP | VOP, string];
-    // TODO! handle non-PARAMETER rhs exprs
-    const param = `${ctx.uniformName}.${rhs}`;
-    if (isVecOp(op)) {
-        const [agg, sop] = parseVecOp(op);
-        const str = `${agg}(${genRef(ctx, lhs)} ${sop} ${param})`; // any / all are built-in wgsl fns over vectors of booleans
-        return str;
-    }
-    return `${genRef(ctx, lhs)} ${op} ${param}`;
-}
-function handlePredElem(ctx: FilterShaderQueryContext<Tables>, e: Elem<PredLst>) {
-    switch (e.OP) {
-        case 'and (':
-            return `&& (${genPred(ctx, e.pred)}`;
-        case 'or (':
-            return `|| (${genPred(ctx, e.pred)}`;
-        case ')':
-            return ')';
-        case 'and':
-            return `&& ${genPred(ctx, e.pred)}`;
-        case 'or':
-            return `|| ${genPred(ctx, e.pred)}`;
-    }
-}
-export function generatePredicateExpr(ctx: FilterShaderQueryContext<Tables>, exprs: [SimplePredExpr, ...PredLst]) {
-    return exprs.map((e) => (typeof e === 'string' ? genPred(ctx, e) : handlePredElem(ctx, e))).join('\n');
-}
-function extractPred(p: SimplePredExpr | Elem<PredLst>): SimplePredExpr | undefined {
-    return typeof p === 'string' ? p : 'pred' in p ? p.pred : undefined;
-}
-export function genUniformParameterStruct(tables: Tables, from: string, exprs: [SimplePredExpr, ...PredLst]) {
-    const fields = exprs.reduce(
-        (acc, cur: SimplePredExpr | Elem<PredLst>) => {
-            const info = extractPredicateInfo(tables, from, extractPred(cur));
-            return info === undefined ? acc : { ...acc, [info[0]]: info[1] };
-        },
-        {} as Record<string, WgslType>
-    );
-
-    const decls = Object.entries(fields)
-        .map(([param, type]) => `${param}:${type}`)
-        .join(',\n');
-
-    return `struct Parameters {
-    ${decls}
-  };
-  `;
-}
-function extractPredicateInfo(tables: Tables, from: string, expr: SimplePredExpr | undefined) {
-    if (expr === undefined) {
-        return undefined;
-    }
-    const [lhs, _op, rhs] = expr.split(' ') as [string, OP | VOP, string];
-    let lhsType = indexExprType(lhs, tables, from) || fieldType(lhs, tables[from]!);
-    if (lhsType) {
-        return [rhs, lhsType] as const;
-    }
-    return undefined;
-}
-
-// we also need to generate a storage buffer per field per table...
-// todo - someday support row-major tables - structs vs. parallel arrays
-export function generateTableBindings(
-    tableName: string,
-    table: Record<string, WgslType>,
-    group: number,
-    bindingStart: number = 0
-) {
-    const cols = Object.entries(table);
-    let bindingLookup = cols.reduce(
-        (acc, [f, _t], index) => ({ ...acc, [f]: index + bindingStart }),
-        {} as Record<string, number>
-    );
-    const decls = cols
-        .map(
-            ([f, t], index) =>
-                `@group(${group}) @binding(${index + bindingStart}) var<storage,read> ${tableName}_${f}: array<${t}>;`
-        )
-        .join('\n');
-    return { decls, numBindings: cols.length, bindingLookup };
-}
+import entries from 'lodash/entries'
 
 function generateOutputStructure(selections: ReadonlyArray<Sel>) {
-    // the names of the values in the structure dont matter at all -
-    const structName = `OutputStruct`;
-    const fields = selections.map((s, i) => `field_${i.toFixed(0)}: ${s.type},`).join('\n');
-    const decl = `struct ${structName} {\n ${fields} \n };`;
-    const initializers = selections.map((s) => s.selection).join(', '); // === '$index' ? 'tmp - 1' : `${s.selection}[tmp - 1]`).join(', ');
-    const construct = `${structName}(${initializers})`;
+  // the names of the values in the structure dont matter at all -
+  const structName = `OutputStruct`
+  const fields = selections.map((s, i) => `field_${i.toFixed(0)}: ${s.type},`).join('\n');
+  const decl = `struct ${structName} {\n ${fields} \n };`;
+  const initializers = selections.map((s) => s.selection).join(', ');
+  const construct = `${structName}(${initializers})`
 
-    return { structName, decl, construct };
+  return {structName,decl,construct}
 }
-
 export function generateShader(params: {
-    workgroupSize: number;
-    inputBindings: string;
-    predicateExpr: string;
-    uniformStruct: { name: string; typeName: string; decl: string };
-    indexed: boolean;
-    selections: ReadonlyArray<Sel>;
+  workgroupSize: number,
+  inputBindings: string,
+  predicateExpr: string,
+  uniformStruct: { name: string, typeName: string, decl: string },
+  indexed: boolean,
+  selections: ReadonlyArray<Sel>
 }) {
-    const { inputBindings, predicateExpr, uniformStruct, selections, workgroupSize, indexed } = params;
-    const { structName, decl: outputStructDecl, construct } = generateOutputStructure(selections);
-    const host = /*wgsl*/ `
+  const { inputBindings, predicateExpr, uniformStruct, selections, workgroupSize, indexed } = params;
+  const {structName, decl, construct } = generateOutputStructure(selections);
+  const host = /*wgsl*/`
 
     ${uniformStruct.decl}
-    ${outputStructDecl}
+    ${decl}
     var<workgroup> results: array<u32,${workgroupSize}>;
     var<workgroup> count: atomic<u32>;
 
@@ -183,7 +38,9 @@ export function generateShader(params: {
     // result count and results are in group1, as they change at the same rate as the input buffers
     @group(1) @binding(0) var<storage,read_write> used: array<atomic<u32>,1>;
     @group(1) @binding(1) var<storage, read_write> passing: array<${structName}>;
-    ${indexed ? '@group(1) @binding(2) var<storage, read_write> elements: array<u32>;' : ''};
+    ${indexed ?
+      '@group(1) @binding(2) var<storage, read_write> elements: array<u32>;' :
+      ''};
 
     // input bindings (find-replace injected...)
     ${inputBindings}
@@ -194,8 +51,7 @@ export function generateShader(params: {
         @builtin(local_invocation_id) local_id: vec3<u32>,
     ){
         let element = ${indexed ? 'elements[global_id.x]' : 'global_id.x'};
-        let inbounds = global_id.x < arrayLength(&passing);
-        let predicateResult = inbounds && ${predicateExpr};
+        let predicateResult = ${predicateExpr};
         if(predicateResult){
             atomicAdd(&count,1u);
             results[local_id.x]=(element+1);
@@ -208,6 +64,10 @@ export function generateShader(params: {
         if(local_id.x==0){
             let c = atomicLoad(&count);
             let start = atomicAdd(&used[0],c);
+            // early return - if the start is past the last result:
+            if(start >= arrayLength(&passing)){
+              return;
+            }
             var p = start;
             for(var i = 0;i < ${workgroupSize};i++){
                 if(results[i]>0){
@@ -217,41 +77,47 @@ export function generateShader(params: {
                 }
             }
         }
-    }`;
+    }`
 
-    return host;
+  return host;
 }
 
-export function genQuery<Ts extends Tables>(
-    ctx: FilterShaderQueryContext<Ts>,
-    predicates: PredLst,
-    wgSize: number,
-    indexed: boolean
-) {
-    // const bindings = generateTableBindings(ctx.from as string, ctx.tables[ctx.from]!, 1)
-    // for now, assume all tables will be used somehow
-    // future - allow specification of which tables go in which groups
-    // const bindings = map(keys(ctx.tables), (t) => generateTableBindings(t, ctx.tables[t]!, 1))
-    let bindingStart = 3;
-    let bindings: string = '';
-    const bindingLookups: Record<string, Record<string, number>> = {};
-    for (const t of Object.keys(ctx.tables)) {
-        const binding = generateTableBindings(t, ctx.tables[t]!, 1, bindingStart);
-        bindings += `\n //${t}\n${binding.decls}\n`;
-        bindingStart += binding.numBindings;
-        bindingLookups[t] = binding.bindingLookup;
-    }
-    const predicate = generatePredicateExpr(ctx, [ctx.firstPred, ...predicates]);
-    const paramsDecl = genUniformParameterStruct(ctx.tables, ctx.from, [ctx.firstPred, ...predicates]);
-    return {
-        shader: generateShader({
-            workgroupSize: wgSize,
-            inputBindings: bindings,
-            predicateExpr: predicate,
-            indexed,
-            selections: ctx.selections.map((s) => ({ selection: genRef(ctx, s.selection, 'tmp - 1'), type: s.type })),
-            uniformStruct: { name: ctx.uniformName, typeName: ctx.uniformTypeName, decl: paramsDecl },
-        }),
-        bindingLookups,
-    };
+export function generateTableBindings(tableName: string, table: Record<string, WgslType>, group: number, bindingStart: number = 0) {
+  const cols = entries(table)
+  let bindingLookup = cols.reduce((acc, [f, _t], index) => ({ ...acc, [f]: index + bindingStart }), {} as Record<string, number>);
+  const decls = cols.map(([f, t], index) => `@group(${group}) @binding(${index + bindingStart}) var<storage,read> ${tableName}_${f}: array<${t}>;`).join('\n');
+  return { decls, numBindings: cols.length, bindingLookup }
+}
+export type FilterCtx<Ts extends Tables> = {
+  from: string;
+  tables: Ts;
+  selections: ReadonlyArray<Sel>;
+  uniformName: string;
+  uniformTypeName: string;
+}
+export function assembleQuery<Ts extends Tables>(ctx: FilterCtx<Ts>,predExpr:string,paramsDecl:string, wgSize: number, indexed: boolean) {
+  let bindingStart = 3;
+  let bindings: string = ''
+  const bindingLookups: Record<string, Record<string, number>> = {}
+  for (const t of Object.keys(ctx.tables)) {
+    const binding = generateTableBindings(t, ctx.tables[t]!, 1, bindingStart)
+    bindings += `\n //${t}\n${binding.decls}\n`;
+    bindingStart += binding.numBindings
+    bindingLookups[t] = binding.bindingLookup
+  }
+  const uniStructDecl = `struct ${ctx.uniformTypeName} {
+      ${paramsDecl}
+    };`
+  return {
+    shader: generateShader(
+      {
+        workgroupSize: wgSize,
+        inputBindings: bindings,
+        predicateExpr: predExpr,
+        indexed,
+        selections: ctx.selections.map(s=>({selection: s.selection, type: s.type})),
+        uniformStruct: { name: ctx.uniformName, typeName: ctx.uniformTypeName, decl: uniStructDecl }
+      }),
+    bindingLookups
+  }
 }

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -3,8 +3,7 @@ import {
     type Sel,
     type Tables,
 } from './types';
-import entries from 'lodash/entries'
-
+const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
 function generateOutputStructure(selections: ReadonlyArray<Sel>) {
   // the names of the values in the structure dont matter at all -
   const structName = `OutputStruct`

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -10,7 +10,7 @@ function generateOutputStructure(selections: ReadonlyArray<Sel>) {
     const initializers = selections.map((s) => s.selection).join(', ');
     const construct = `${structName}(${initializers})`;
 
-    return { structName,  structDecl, construct };
+    return { structName, structDecl, construct };
 }
 export function generateShader(params: {
     workgroupSize: number;

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -1,30 +1,26 @@
-import {
-    type WgslType,
-    type Sel,
-    type Tables,
-} from './types';
+import { type WgslType, type Sel, type Tables } from './types';
 const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
 function generateOutputStructure(selections: ReadonlyArray<Sel>) {
-  // the names of the values in the structure dont matter at all -
-  const structName = `OutputStruct`
-  const fields = selections.map((s, i) => `field_${i.toFixed(0)}: ${s.type},`).join('\n');
-  const decl = `struct ${structName} {\n ${fields} \n };`;
-  const initializers = selections.map((s) => s.selection).join(', ');
-  const construct = `${structName}(${initializers})`
+    // the names of the values in the structure dont matter at all -
+    const structName = `OutputStruct`;
+    const fields = selections.map((s, i) => `field_${i.toFixed(0)}: ${s.type},`).join('\n');
+    const decl = `struct ${structName} {\n ${fields} \n };`;
+    const initializers = selections.map((s) => s.selection).join(', ');
+    const construct = `${structName}(${initializers})`;
 
-  return {structName,decl,construct}
+    return { structName, decl, construct };
 }
 export function generateShader(params: {
-  workgroupSize: number,
-  inputBindings: string,
-  predicateExpr: string,
-  uniformStruct: { name: string, typeName: string, decl: string },
-  indexed: boolean,
-  selections: ReadonlyArray<Sel>
+    workgroupSize: number;
+    inputBindings: string;
+    predicateExpr: string;
+    uniformStruct: { name: string; typeName: string; decl: string };
+    indexed: boolean;
+    selections: ReadonlyArray<Sel>;
 }) {
-  const { inputBindings, predicateExpr, uniformStruct, selections, workgroupSize, indexed } = params;
-  const {structName, decl, construct } = generateOutputStructure(selections);
-  const host = /*wgsl*/`
+    const { inputBindings, predicateExpr, uniformStruct, selections, workgroupSize, indexed } = params;
+    const { structName, decl, construct } = generateOutputStructure(selections);
+    const host = /*wgsl*/ `
 
     ${uniformStruct.decl}
     ${decl}
@@ -37,9 +33,7 @@ export function generateShader(params: {
     // result count and results are in group1, as they change at the same rate as the input buffers
     @group(1) @binding(0) var<storage,read_write> used: array<atomic<u32>,1>;
     @group(1) @binding(1) var<storage, read_write> passing: array<${structName}>;
-    ${indexed ?
-      '@group(1) @binding(2) var<storage, read_write> elements: array<u32>;' :
-      ''};
+    ${indexed ? '@group(1) @binding(2) var<storage, read_write> elements: array<u32>;' : ''};
 
     // input bindings (find-replace injected...)
     ${inputBindings}
@@ -76,47 +70,65 @@ export function generateShader(params: {
                 }
             }
         }
-    }`
+    }`;
 
-  return host;
+    return host;
 }
 
-export function generateTableBindings(tableName: string, table: Record<string, WgslType>, group: number, bindingStart: number = 0) {
-  const cols = entries(table)
-  let bindingLookup = cols.reduce((acc, [f, _t], index) => ({ ...acc, [f]: index + bindingStart }), {} as Record<string, number>);
-  const decls = cols.map(([f, t], index) => `@group(${group}) @binding(${index + bindingStart}) var<storage,read> ${tableName}_${f}: array<${t}>;`).join('\n');
-  return { decls, numBindings: cols.length, bindingLookup }
+export function generateTableBindings(
+    tableName: string,
+    table: Record<string, WgslType>,
+    group: number,
+    bindingStart: number = 0
+) {
+    const cols = entries(table);
+    let bindingLookup = cols.reduce(
+        (acc, [f, _t], index) => ({ ...acc, [f]: index + bindingStart }),
+        {} as Record<string, number>
+    );
+    const decls = cols
+        .map(
+            ([f, t], index) =>
+                `@group(${group}) @binding(${index + bindingStart}) var<storage,read> ${tableName}_${f}: array<${t}>;`
+        )
+        .join('\n');
+    return { decls, numBindings: cols.length, bindingLookup };
 }
 export type FilterCtx<Ts extends Tables> = {
-  from: string;
-  tables: Ts;
-  selections: ReadonlyArray<Sel>;
-  uniformName: string;
-  uniformTypeName: string;
-}
-export function assembleQuery<Ts extends Tables>(ctx: FilterCtx<Ts>,predExpr:string,paramsDecl:string, wgSize: number, indexed: boolean) {
-  let bindingStart = 3;
-  let bindings: string = ''
-  const bindingLookups: Record<string, Record<string, number>> = {}
-  for (const t of Object.keys(ctx.tables)) {
-    const binding = generateTableBindings(t, ctx.tables[t]!, 1, bindingStart)
-    bindings += `\n //${t}\n${binding.decls}\n`;
-    bindingStart += binding.numBindings
-    bindingLookups[t] = binding.bindingLookup
-  }
-  const uniStructDecl = `struct ${ctx.uniformTypeName} {
+    from: string;
+    tables: Ts;
+    selections: ReadonlyArray<Sel>;
+    uniformName: string;
+    uniformTypeName: string;
+};
+export function assembleQuery<Ts extends Tables>(
+    ctx: FilterCtx<Ts>,
+    predExpr: string,
+    paramsDecl: string,
+    wgSize: number,
+    indexed: boolean
+) {
+    let bindingStart = 3;
+    let bindings: string = '';
+    const bindingLookups: Record<string, Record<string, number>> = {};
+    for (const t of Object.keys(ctx.tables)) {
+        const binding = generateTableBindings(t, ctx.tables[t]!, 1, bindingStart);
+        bindings += `\n //${t}\n${binding.decls}\n`;
+        bindingStart += binding.numBindings;
+        bindingLookups[t] = binding.bindingLookup;
+    }
+    const uniStructDecl = `struct ${ctx.uniformTypeName} {
       ${paramsDecl}
-    };`
-  return {
-    shader: generateShader(
-      {
-        workgroupSize: wgSize,
-        inputBindings: bindings,
-        predicateExpr: predExpr,
-        indexed,
-        selections: ctx.selections.map(s=>({selection: s.selection, type: s.type})),
-        uniformStruct: { name: ctx.uniformName, typeName: ctx.uniformTypeName, decl: uniStructDecl }
-      }),
-    bindingLookups
-  }
+    };`;
+    return {
+        shader: generateShader({
+            workgroupSize: wgSize,
+            inputBindings: bindings,
+            predicateExpr: predExpr,
+            indexed,
+            selections: ctx.selections.map((s) => ({ selection: s.selection, type: s.type })),
+            uniformStruct: { name: ctx.uniformName, typeName: ctx.uniformTypeName, decl: uniStructDecl },
+        }),
+        bindingLookups,
+    };
 }

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -1,8 +1,6 @@
 import { type WgslType, type Sel, type Tables } from './types';
 
-// lodash is being really troublesome.. so I wrote my own here
-/* oxlint-disable no-console, typescript/no-explicit-any*/
-const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
+const entries = (r: object)=> Object.entries(r);
 
 function generateOutputStructure(selections: ReadonlyArray<Sel>) {
     // the names of the values in the structure dont matter at all -

--- a/packages/core/src/rendering/webgpu/filter/query.test.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from "vitest";
+import { given } from "./query";
+
+describe("expression building", () => {
+  const tables = {
+    cells: { A: "vec2f", B: "u32" },
+    edges: { E: "vec2u", str: "f32" },
+  } as const;
+  const { column, table,clause } = given(tables).from("edges");
+
+  test("indexing a table with a swizzled vector", () => {
+    const f32 = table("cells").at("E.x").dot("A.y");
+    const vec2f = table("cells").at("E.y").dot("A");
+    expect(f32).toEqual({
+      kind: "table at field",
+      table: "cells",
+      atExpr:"E.x",
+      field: "A.y",
+      type: "f32",
+    });
+    expect(vec2f).toEqual({
+      kind: "table at field",
+      table: "cells",
+      atExpr:"E.y",
+      field: "A",
+      type: "vec2f",
+    });
+  });
+  test("simple column reference", () => {
+    const u32 = column('E.x')
+    const f32 = column('str')
+    expect(f32).toEqual({
+      kind: "from field",
+      field: "str",
+      from:'edges',
+      type: "f32",
+    });
+    expect(u32).toEqual({
+      kind: "from field",
+      field: "E.x",
+      from:'edges',
+      type: "u32",
+    });
+  });
+  test("nested table index", () => {
+    const fancy = table('cells').at(
+      table('cells').at('E.x').dot('B')
+    ).dot('A.x')
+    expect(fancy).toEqual({
+      kind: "table at field",
+      table: "cells",
+      atExpr: {
+          kind: "table at field",
+          table: "cells",
+          atExpr: 'E.x',
+          field: 'B',
+          type:'u32',
+      },
+      field: "A.x",
+      type: "f32",
+    })
+  });
+  test('predicate', () => {
+    const p = clause(table("cells").at("E.x").dot("A.y"), '==', 'stuff')
+    expect(p.predicates).toHaveLength(1)
+    expect(p.predicates[0]).toEqual({
+      kind: 'predicate',
+      lhs: {
+        kind: "table at field",
+        table: "cells",
+        atExpr:"E.x",
+        field: "A.y",
+        type: "f32",
+      },
+      op: '==',
+      rhs:'stuff'
+    })
+  })
+});

--- a/packages/core/src/rendering/webgpu/filter/query.test.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.test.ts
@@ -1,79 +1,77 @@
-import { describe, expect, test } from "vitest";
-import { given } from "./query";
+import { describe, expect, test } from 'vitest';
+import { given } from './query';
 
-describe("expression building", () => {
-  const tables = {
-    cells: { A: "vec2f", B: "u32" },
-    edges: { E: "vec2u", str: "f32" },
-  } as const;
-  const { column, table,clause } = given(tables).from("edges");
+describe('expression building', () => {
+    const tables = {
+        cells: { A: 'vec2f', B: 'u32' },
+        edges: { E: 'vec2u', str: 'f32' },
+    } as const;
+    const { column, table, clause } = given(tables).from('edges');
 
-  test("indexing a table with a swizzled vector", () => {
-    const f32 = table("cells").at("E.x").dot("A.y");
-    const vec2f = table("cells").at("E.y").dot("A");
-    expect(f32).toEqual({
-      kind: "table at field",
-      table: "cells",
-      atExpr:"E.x",
-      field: "A.y",
-      type: "f32",
+    test('indexing a table with a swizzled vector', () => {
+        const f32 = table('cells').at('E.x').dot('A.y');
+        const vec2f = table('cells').at('E.y').dot('A');
+        expect(f32).toEqual({
+            kind: 'table at field',
+            table: 'cells',
+            atExpr: 'E.x',
+            field: 'A.y',
+            type: 'f32',
+        });
+        expect(vec2f).toEqual({
+            kind: 'table at field',
+            table: 'cells',
+            atExpr: 'E.y',
+            field: 'A',
+            type: 'vec2f',
+        });
     });
-    expect(vec2f).toEqual({
-      kind: "table at field",
-      table: "cells",
-      atExpr:"E.y",
-      field: "A",
-      type: "vec2f",
+    test('simple column reference', () => {
+        const u32 = column('E.x');
+        const f32 = column('str');
+        expect(f32).toEqual({
+            kind: 'from field',
+            field: 'str',
+            from: 'edges',
+            type: 'f32',
+        });
+        expect(u32).toEqual({
+            kind: 'from field',
+            field: 'E.x',
+            from: 'edges',
+            type: 'u32',
+        });
     });
-  });
-  test("simple column reference", () => {
-    const u32 = column('E.x')
-    const f32 = column('str')
-    expect(f32).toEqual({
-      kind: "from field",
-      field: "str",
-      from:'edges',
-      type: "f32",
+    test('nested table index', () => {
+        const fancy = table('cells').at(table('cells').at('E.x').dot('B')).dot('A.x');
+        expect(fancy).toEqual({
+            kind: 'table at field',
+            table: 'cells',
+            atExpr: {
+                kind: 'table at field',
+                table: 'cells',
+                atExpr: 'E.x',
+                field: 'B',
+                type: 'u32',
+            },
+            field: 'A.x',
+            type: 'f32',
+        });
     });
-    expect(u32).toEqual({
-      kind: "from field",
-      field: "E.x",
-      from:'edges',
-      type: "u32",
+    test('predicate', () => {
+        const p = clause(table('cells').at('E.x').dot('A.y'), '==', 'stuff');
+        expect(p.predicates).toHaveLength(1);
+        expect(p.predicates[0]).toEqual({
+            kind: 'predicate',
+            lhs: {
+                kind: 'table at field',
+                table: 'cells',
+                atExpr: 'E.x',
+                field: 'A.y',
+                type: 'f32',
+            },
+            op: '==',
+            rhs: 'stuff',
+        });
     });
-  });
-  test("nested table index", () => {
-    const fancy = table('cells').at(
-      table('cells').at('E.x').dot('B')
-    ).dot('A.x')
-    expect(fancy).toEqual({
-      kind: "table at field",
-      table: "cells",
-      atExpr: {
-          kind: "table at field",
-          table: "cells",
-          atExpr: 'E.x',
-          field: 'B',
-          type:'u32',
-      },
-      field: "A.x",
-      type: "f32",
-    })
-  });
-  test('predicate', () => {
-    const p = clause(table("cells").at("E.x").dot("A.y"), '==', 'stuff')
-    expect(p.predicates).toHaveLength(1)
-    expect(p.predicates[0]).toEqual({
-      kind: 'predicate',
-      lhs: {
-        kind: "table at field",
-        table: "cells",
-        atExpr:"E.x",
-        field: "A.y",
-        type: "f32",
-      },
-      op: '==',
-      rhs:'stuff'
-    })
-  })
 });

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -31,7 +31,7 @@ import * as lo from 'lodash';
 import { logger } from '~/src/logger';
 const { mapValues } = lo;
 
-const entries = <T extends {}>(r: T):ReadonlyArray<[string, T[keyof T]]> => Object.entries(r) ;
+const entries = <T extends {}>(r: T): ReadonlyArray<[string, T[keyof T]]> => Object.entries(r);
 
 function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
     lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
@@ -145,9 +145,9 @@ function componentType(t: WgslType): ScalarType {
     }
     return t as ScalarType;
 }
-function inferType(table:ITable,e: string) {
-  const [field, swizzle] = e.split('.');
-  return swizzle ? componentType(table![field!]!) : table![field!]!;
+function inferType(table: ITable, e: string) {
+    const [field, swizzle] = e.split('.');
+    return swizzle ? componentType(table![field!]!) : table![field!]!;
 }
 function determineType(
     tables: Tables,
@@ -174,7 +174,7 @@ function mapTablesToBindings<Ts extends Tables>(
             return entries(table).map(([field, buffer]) => {
                 const b = lookups[name]?.[field];
                 if (b) {
-                  return { resource: buffer as GPUBuffer, binding: b };
+                    return { resource: buffer as GPUBuffer, binding: b };
                 }
                 return undefined;
             });
@@ -210,11 +210,9 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
             .map(([name, type]) => `${name}:${type}`)
             .join(',\n');
 
-      const { tables } = this;
+        const { tables } = this;
 
-
-
-      const predicateExpr = `(${compilePredicate(this.toWgsl, predicates, UNI_INSTANCE_NAME)})`;
+        const predicateExpr = `(${compilePredicate(this.toWgsl, predicates, UNI_INSTANCE_NAME)})`;
         let binding = START_BINDING;
         let columnBindings: Record<string, Record<string, number>> = {};
         // associate a binding with every field of every table
@@ -366,7 +364,9 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                 enc.copyBufferToBuffer(results, resolve);
                 dev.queue.submit([enc.finish()]);
                 // ok now get the results and compare them!
-                resolve.mapAsync(GPUMapMode.READ).then(() => {
+                resolve
+                    .mapAsync(GPUMapMode.READ)
+                    .then(() => {
                         const recvd = resolve.getMappedRange();
                         const dv = new DataView(recvd);
                         const ex = new DataView(expected.buffer);
@@ -392,46 +392,46 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
 
             return { runner, validate };
         };
-        const buildHelper = <Indexed extends boolean>(device: GPUDevice,label:string,indexed:Indexed) => {
-          const Q = assembleQuery(
-              {
-                  from: this.from as string,
-                  selections: this.selections,
-                  tables,
-                  uniformName: UNI_INSTANCE_NAME,
-                  uniformTypeName: UNI_STRUCT_TYPE_NAME,
-              },
-              predicateExpr,
-              paramDecls,
-              64,
-              indexed
-          );
-          const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-          const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
-          const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-              const unis = wgh.makeStructuredView(uniDef, buffer);
-              unis.set(parameters);
-              return unis.arrayBuffer;
-          };
+        const buildHelper = <Indexed extends boolean>(device: GPUDevice, label: string, indexed: Indexed) => {
+            const Q = assembleQuery(
+                {
+                    from: this.from as string,
+                    selections: this.selections,
+                    tables,
+                    uniformName: UNI_INSTANCE_NAME,
+                    uniformTypeName: UNI_STRUCT_TYPE_NAME,
+                },
+                predicateExpr,
+                paramDecls,
+                64,
+                indexed
+            );
+            const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+            const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+            const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+                const unis = wgh.makeStructuredView(uniDef, buffer);
+                unis.set(parameters);
+                return unis.arrayBuffer;
+            };
 
-          const { runner, validate } = makeRunner({
-              device,
-              indexed,
-              label,
-              pipe,
-              safeLookups: columnBindings,
-              serializeParameters,
-              shader: Q.shader,
-              wgSize: WG_SIZE,
-          });
-          return {
-              run: runner,
-              validate,
-              serializeParameters,
-              pipeline: pipe,
-              parameterTypeDef: uniDef,
-          };
-        }
+            const { runner, validate } = makeRunner({
+                device,
+                indexed,
+                label,
+                pipe,
+                safeLookups: columnBindings,
+                serializeParameters,
+                shader: Q.shader,
+                wgSize: WG_SIZE,
+            });
+            return {
+                run: runner,
+                validate,
+                serializeParameters,
+                pipeline: pipe,
+                parameterTypeDef: uniDef,
+            };
+        };
         return {
             shaderOnly: () => {
                 const Q = assembleQuery(
@@ -448,10 +448,10 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                     false
                 );
                 return Q.shader;
-          },
+            },
 
             build: (device: GPUDevice, label: string) => {
-              return buildHelper(device, label, false);
+                return buildHelper(device, label, false);
             },
             buildIndexed: (device: GPUDevice, label: string) => {
                 return buildHelper(device, label, true);
@@ -473,40 +473,36 @@ export function given<Ts extends Tables>(tables: Ts) {
     }
     // these are fun...  they do belong in types.ts, but moving them there means they no longer directly deal with Ts
     // I think that discconnect pushes TS over the edge and they end up not working - everything turns to unknown
-    type UnionToIntersection<U> =
-      (U extends any ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never
-    type ExpandTableColumn<T extends keyof Ts,F extends keyof Ts[T]> = F extends string ? vKeys<Ts[T], F> & T : never
-    type ExpandTableVectors<T extends keyof Ts> = keyof Ts[T] extends string ? UnionToIntersection<ExpandTableColumn<T, keyof Ts[T]>>:never
+    type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
+    type ExpandTableColumn<T extends keyof Ts, F extends keyof Ts[T]> = F extends string ? vKeys<Ts[T], F> & T : never;
+    type ExpandTableVectors<T extends keyof Ts> = keyof Ts[T] extends string
+        ? UnionToIntersection<ExpandTableColumn<T, keyof Ts[T]>>
+        : never;
     return {
         from: <From extends keyof Ts>(from: From) => {
             function column<E extends keyof ExpandTableVectors<From>>(
                 k: E
-            ):ColumnExpr<string,string,ExpandTableVectors<From>[E]>{
+            ): ColumnExpr<string, string, ExpandTableVectors<From>[E]> {
                 return {
                     kind: 'from field',
                     from: from as string,
                     field: k as string,
-                    type: inferType(tables[from],k as string) as ExpandTableVectors<From>[E]
-                }
+                    type: inferType(tables[from], k as string) as ExpandTableVectors<From>[E],
+                };
             }
             function table<Other extends Exclude<keyof Ts, From>>(t: Other) {
-
                 return {
                     at: <E extends SwizzleIndexExpr<Ts, From, keyof Ts[From]>>(
                         indexExpr: E | IndexExpr<string, string, 'u32'>
                     ) => {
-
-
                         return {
-                          dot: <OE extends keyof ExpandTableVectors<Other>>(
-                                field: OE
-                            ) => {
-                              const IE: IndexExpr<string, string,ExpandTableVectors<Other>[OE]> = {
+                            dot: <OE extends keyof ExpandTableVectors<Other>>(field: OE) => {
+                                const IE: IndexExpr<string, string, ExpandTableVectors<Other>[OE]> = {
                                     kind: 'table at field',
                                     table: t as string,
                                     field: field as string,
                                     atExpr: indexExpr,
-                                    type: inferType(tables[t],field as string) as ExpandTableVectors<Other>[OE]
+                                    type: inferType(tables[t], field as string) as ExpandTableVectors<Other>[OE],
                                 };
                                 return IE;
                             },
@@ -533,10 +529,10 @@ type Parameters = Record<string, string | number | number[]>;
 // this function is not exported or called - its only purpose is to explode if something in the above file
 // changes enough to mess up the types - we want restrictive types here, its the whole point
 function typescriptCanary() {
-  type hey = { cells: { A: 'f32', B: 'vec2f' }, edges: { E: 'vec2u', str: 'f32' } }
-  const e = given({ cells: { A: 'f32', B: 'vec2f' }, edges: { E: 'vec2u', str: 'f32' } }).from('edges')
-  // @ts-expect-error
-  e.select('$index').where(e.clause(e.table('cells').at('E.x').dot('B'), '==', 'mom'))
-  // @ts-expect-error
-  e.select('$index').where(e.clause(e.column('E.x'), 'all(==)', 'mom'))
+    type hey = { cells: { A: 'f32'; B: 'vec2f' }; edges: { E: 'vec2u'; str: 'f32' } };
+    const e = given({ cells: { A: 'f32', B: 'vec2f' }, edges: { E: 'vec2u', str: 'f32' } }).from('edges');
+    // @ts-expect-error
+    e.select('$index').where(e.clause(e.table('cells').at('E.x').dot('B'), '==', 'mom'));
+    // @ts-expect-error
+    e.select('$index').where(e.clause(e.column('E.x'), 'all(==)', 'mom'));
 }

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -46,7 +46,10 @@ function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P exten
 }
 class Clause<Params extends Record<string, string | number | number[]>> {
     predicates: Array<PExpr<`${alpha}${string}`>>;
-    constructor(readonly tables:Tables, preds: Array<ReturnType<typeof predicate<VLen, WgslType, `${alpha}${string}`>>>) {
+    constructor(
+        readonly tables: Tables,
+        preds: Array<ReturnType<typeof predicate<VLen, WgslType, `${alpha}${string}`>>>
+    ) {
         this.predicates = preds;
     }
     or<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
@@ -54,11 +57,11 @@ class Clause<Params extends Record<string, string | number | number[]>> {
         op: L extends ScalarType ? OP : VOP,
         rhs: onlyLetters<P>
     ) {
-        return new Clause<Params & { [k in P]: TsType<L> }>(this.tables,[...this.predicates, predicate(lhs, op, rhs)]);
+        return new Clause<Params & { [k in P]: TsType<L> }>(this.tables, [...this.predicates, predicate(lhs, op, rhs)]);
     }
     paramDeclarations() {
         return this.predicates.reduce(
-            (acc, p) => ({ ...acc, [p.rhs]: determineType(this.tables,p.lhs) }),
+            (acc, p) => ({ ...acc, [p.rhs]: determineType(this.tables, p.lhs) }),
             {} as Record<string, string>
         );
     }
@@ -89,33 +92,31 @@ function parseVecOp(op: VOP) {
     return [aggregation, sop] as ['any' | 'all', OP];
 }
 
-function setupExprBuilder(from:string) {
-  function toWgsl(ast: AST, indexing: string, uniName: string): string {
-      switch (ast.kind) {
-          case 'from field': {
-              const [column, swizzle] = ast.field.split('.');
-              return swizzle
-                  ? `${ast.from}_${column}[${indexing}].${swizzle}`
-                  : `${ast.from}_${column}[${indexing}]`;
-          }
-          case 'table at field':
-              const subExpr =
-                  typeof ast.atExpr === 'string'
-                      ? `[${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: undefined as any }, indexing, uniName)}]`
-                      : `[${toWgsl(ast.atExpr, indexing, uniName)}]`;
-              const [column, swizzle] = ast.field.split('.');
-              const sel: string = `${ast.table}_${column}${subExpr}`;
-              return swizzle ? `${sel}.${swizzle}` : sel;
-          case 'predicate':
-              const { lhs, op, rhs } = ast;
-              if (isVecOp(op)) {
-                  const [agg, sop] = parseVecOp(op);
-                  return `${agg}(${toWgsl(lhs, indexing, uniName)} ${sop} ${uniName}.${rhs})`;
-              }
-              return `${toWgsl(lhs, indexing, uniName)} ${op} ${uniName}.${rhs}`;
-      }
-  }
-  return toWgsl;
+function setupExprBuilder(from: string) {
+    function toWgsl(ast: AST, indexing: string, uniName: string): string {
+        switch (ast.kind) {
+            case 'from field': {
+                const [column, swizzle] = ast.field.split('.');
+                return swizzle ? `${ast.from}_${column}[${indexing}].${swizzle}` : `${ast.from}_${column}[${indexing}]`;
+            }
+            case 'table at field':
+                const subExpr =
+                    typeof ast.atExpr === 'string'
+                        ? `[${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: undefined as any }, indexing, uniName)}]`
+                        : `[${toWgsl(ast.atExpr, indexing, uniName)}]`;
+                const [column, swizzle] = ast.field.split('.');
+                const sel: string = `${ast.table}_${column}${subExpr}`;
+                return swizzle ? `${sel}.${swizzle}` : sel;
+            case 'predicate':
+                const { lhs, op, rhs } = ast;
+                if (isVecOp(op)) {
+                    const [agg, sop] = parseVecOp(op);
+                    return `${agg}(${toWgsl(lhs, indexing, uniName)} ${sop} ${uniName}.${rhs})`;
+                }
+                return `${toWgsl(lhs, indexing, uniName)} ${op} ${uniName}.${rhs}`;
+        }
+    }
+    return toWgsl;
 }
 
 function compilePredicate<Params extends Record<string, string | number | number[]>>(
@@ -144,7 +145,7 @@ function componentType(t: WgslType): ScalarType {
     return t as ScalarType;
 }
 function determineType(
-    tables:Tables,
+    tables: Tables,
     expr: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
 ): WgslType {
     if (expr === '$index') return 'u32';
@@ -162,9 +163,8 @@ function determineType(
 function mapTablesToBindings<Ts extends Tables>(
     tables: BufferTables<Ts>,
     lookups: Record<string, Record<string, number>>
-):{resource:GPUBuffer,binding:number}[]
-{
-  return entries(tables)
+): { resource: GPUBuffer; binding: number }[] {
+    return entries(tables)
         .flatMap(([name, table]) => {
             return entries(table).map(([field, buffer]) => {
                 // I promise, these are all strings, its ok
@@ -178,19 +178,21 @@ function mapTablesToBindings<Ts extends Tables>(
         })
         .filter((x) => x !== undefined);
 }
-class Selection<Ts extends Tables,From extends keyof Ts> {
-  selections: ReadonlyArray<Sel>;
-  toWgsl: ReturnType<typeof setupExprBuilder>;
-    constructor(readonly tables:Ts,readonly from:From, selections: ReadonlyArray<Sel>) {
-      this.selections = selections;
-      this.toWgsl = setupExprBuilder(this.from as string);
-    }
-    select(
-        selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
+class Selection<Ts extends Tables, From extends keyof Ts> {
+    selections: ReadonlyArray<Sel>;
+    toWgsl: ReturnType<typeof setupExprBuilder>;
+    constructor(
+        readonly tables: Ts,
+        readonly from: From,
+        selections: ReadonlyArray<Sel>
     ) {
+        this.selections = selections;
+        this.toWgsl = setupExprBuilder(this.from as string);
+    }
+    select(selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>) {
         const s = selection === '$index' ? 'tmp - 1' : this.toWgsl(selection, 'tmp - 1', ''); // uni-name not relavant in selection...
-        const type = determineType(this.tables,selection);
-        return new Selection(this.tables,this.from,[...this.selections, { selection: s, type }]);
+        const type = determineType(this.tables, selection);
+        return new Selection(this.tables, this.from, [...this.selections, { selection: s, type }]);
     }
     where<Params extends Parameters>(predicates: AndGroup<Params> | Clause<Params>) {
         // constants //
@@ -205,9 +207,9 @@ class Selection<Ts extends Tables,From extends keyof Ts> {
             .join(',\n');
         // const uniDecl = `struct ${UNI_STRUCT_NAME} {
         //   ${paramDecls}
-      //   };`
-      const { tables } = this;
-        const predicateExpr = `(${compilePredicate(this.toWgsl,predicates, UNI_INSTANCE_NAME)})`;
+        //   };`
+        const { tables } = this;
+        const predicateExpr = `(${compilePredicate(this.toWgsl, predicates, UNI_INSTANCE_NAME)})`;
         let binding = START_BINDING;
         let columnBindings: Record<string, Record<string, number>> = {};
         // associate a binding with every field of every table
@@ -218,175 +220,177 @@ class Selection<Ts extends Tables,From extends keyof Ts> {
                 binding += 1;
             }
         }
-      const makeRunner = <Indexed extends boolean>(options: {
-        device: GPUDevice;
-        pipe: ReturnType<typeof buildFilterPipeline>;
-        shader: string;
-        safeLookups: Record<string, Record<string, number>>;
-        indexed: Indexed;
-        label: string;
-        wgSize: number;
-        serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer;
-      }) => {
-        const { device, pipe, safeLookups, indexed, label, wgSize } = options;
-        const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
-          const { enc, parameters, sets, timestampWrites } = args;
-          // here, we zero out the result counters
-          // TODO - consider not doing this - if we didnt do that:
-          // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
-          // 2. we technically could invoke this whole thing in an open compute pass...? right?
-          args.sets.forEach((s) => {
-            device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
-          });
-          const bindings = indexed
-            ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
-              return device.createBindGroup({
-                layout: pipe.pipeline.getBindGroupLayout(1),
-                entries: [
-                  { binding: 0, resource: s.resultCounter },
-                  { binding: 1, resource: s.results },
-                  { binding: 2, resource: s.elements },
-                  ...mapTablesToBindings(s.tables, safeLookups),
-                ],
-              });
-            })
-            : args.sets.map((s, i) => {
-              return device.createBindGroup({
-                layout: pipe.pipeline.getBindGroupLayout(1),
-                entries: [
-                  { binding: 0, resource: s.resultCounter },
-                  { binding: 1, resource: s.results },
-                  ...mapTablesToBindings(s.tables, safeLookups),
-                ],
-              });
-            });
+        const makeRunner = <Indexed extends boolean>(options: {
+            device: GPUDevice;
+            pipe: ReturnType<typeof buildFilterPipeline>;
+            shader: string;
+            safeLookups: Record<string, Record<string, number>>;
+            indexed: Indexed;
+            label: string;
+            wgSize: number;
+            serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer;
+        }) => {
+            const { device, pipe, safeLookups, indexed, label, wgSize } = options;
+            const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
+                const { enc, parameters, sets, timestampWrites } = args;
+                // here, we zero out the result counters
+                // TODO - consider not doing this - if we didnt do that:
+                // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
+                // 2. we technically could invoke this whole thing in an open compute pass...? right?
+                args.sets.forEach((s) => {
+                    device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
+                });
+                const bindings = indexed
+                    ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
+                          return device.createBindGroup({
+                              layout: pipe.pipeline.getBindGroupLayout(1),
+                              entries: [
+                                  { binding: 0, resource: s.resultCounter },
+                                  { binding: 1, resource: s.results },
+                                  { binding: 2, resource: s.elements },
+                                  ...mapTablesToBindings(s.tables, safeLookups),
+                              ],
+                          });
+                      })
+                    : args.sets.map((s, i) => {
+                          return device.createBindGroup({
+                              layout: pipe.pipeline.getBindGroupLayout(1),
+                              entries: [
+                                  { binding: 0, resource: s.resultCounter },
+                                  { binding: 1, resource: s.results },
+                                  ...mapTablesToBindings(s.tables, safeLookups),
+                              ],
+                          });
+                      });
 
-          const bg0 = device.createBindGroup({
-            layout: pipe.pipeline.getBindGroupLayout(0),
-            entries: [{ binding: 0, resource: parameters }],
-          });
+                const bg0 = device.createBindGroup({
+                    layout: pipe.pipeline.getBindGroupLayout(0),
+                    entries: [{ binding: 0, resource: parameters }],
+                });
 
-          const pass = enc.beginComputePass(
-            timestampWrites
-              ? {
-                label,
-                timestampWrites,
-              }
-              : { label }
-          );
-          pass.setPipeline(pipe.pipeline);
-          pass.setBindGroup(0, bg0);
-          for (let i = 0; i < sets.length; i++) {
-            const s = sets[i]!;
-            const bg1 = bindings[i]!;
-            // console.log('running filter-->',s.results.label)
-            pass.setBindGroup(1, bg1);
-            const dispatchCount = Math.ceil(s.rowCount / wgSize);
-            pass.dispatchWorkgroups(dispatchCount);
-          }
-          pass.end();
-        };
-        function validate(
-          dev: GPUDevice,
-          serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer,
-          tables: ArrayBufferTables<Ts>,
-          params: Params,
-          expected: { buffer: ArrayBuffer },
-          elements: Uint32Array | number
-        ) {
-          const R = GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
-          const M = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
-          const enc = dev.createCommandEncoder();
-          const pBytes = serializeParameters(params);
-          const paramB = dev.createBuffer({
-            size: pBytes.byteLength,
-            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
-            label: 'validate params',
-          });
-          dev.queue.writeBuffer(paramB, 0, pBytes);
-          const inputs: GPUBuffer[] = [];
-
-          const tableBuffers: BufferTables<Ts> = mapValues(tables, (table: Record<string, { buffer: ArrayBuffer }>) =>
-            mapValues(table, (column: { buffer: ArrayBuffer }) => {
-              const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
-              dev.queue.writeBuffer(buf, 0, column.buffer);
-              inputs.push(buf);
-              return buf;
-            })
-          ) as BufferTables<Ts>; // TS cant tell, mapValues I think does erase the info...
-
-          const rowCount: number = elements instanceof Uint32Array ? elements.length : elements;
-          let elemBuffer: GPUBuffer | undefined;
-          if (elements instanceof Uint32Array) {
-            elemBuffer = dev.createBuffer({ size: elements.buffer.byteLength, usage: R });
-            dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
-          }
-          const resultsCounter = dev.createBuffer({ size: 16, usage: R });
-          const resolveCount = dev.createBuffer({ size: 16, usage: M });
-          const results = dev.createBuffer({ size: rowCount * 32, usage: R });
-          const resolve = dev.createBuffer({ size: rowCount * 32, usage: M });
-          // very awkward a bit longwinded, and there are some TS issues, but its ok!
-          if (indexed) {
-            const iArgs: RunIndexedFilterArgs<Ts> = {
-              enc,
-              parameters: paramB,
-              sets: [
-                {
-                  elements: elemBuffer!,
-                  resultCounter: resultsCounter,
-                  results,
-                  rowCount,
-                  tables: tableBuffers,
-                },
-              ],
-            };
-            (runner as (args: RunIndexedFilterArgs<Ts>) => void)(iArgs);
-          } else {
-            const args: RunFilterArgs<Ts> = {
-              enc,
-              parameters: paramB,
-              sets: [
-                {
-                  resultCounter: resultsCounter,
-                  results,
-                  rowCount,
-                  tables: tableBuffers,
-                },
-              ],
-            };
-            (runner as (args: RunFilterArgs<Ts>) => void)(args);
-          }
-          enc.copyBufferToBuffer(results, resolve);
-          enc.copyBufferToBuffer(resultsCounter, resolveCount);
-          dev.queue.submit([enc.finish()]);
-          // ok now get the results and compare them!
-          Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)])
-            .then(() => {
-              const count = new Uint32Array(resolveCount.getMappedRange());
-              const recvd = resolve.getMappedRange();
-              // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
-              // if(count[0]!==expected)
-              const dv = new DataView(recvd);
-              const ex = new DataView(expected.buffer);
-              let failBytes = 0;
-              for (let i = 0; i < expected.buffer.byteLength; i++) {
-                if (dv.getUint8(i) !== ex.getUint8(i)) {
-                  console.error('filter validation failed at byte: ', i);
-                  failBytes += 1;
+                const pass = enc.beginComputePass(
+                    timestampWrites
+                        ? {
+                              label,
+                              timestampWrites,
+                          }
+                        : { label }
+                );
+                pass.setPipeline(pipe.pipeline);
+                pass.setBindGroup(0, bg0);
+                for (let i = 0; i < sets.length; i++) {
+                    const s = sets[i]!;
+                    const bg1 = bindings[i]!;
+                    // console.log('running filter-->',s.results.label)
+                    pass.setBindGroup(1, bg1);
+                    const dispatchCount = Math.ceil(s.rowCount / wgSize);
+                    pass.dispatchWorkgroups(dispatchCount);
                 }
-              }
-              if (failBytes === 0) {
-                console.log('validation success');
-              }
-            })
-            .finally(() => {
-              // destroy all things
-              [resolve, resolveCount, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
-              if (elemBuffer) {
-                elemBuffer.destroy();
-              }
-            });
-        }
+                pass.end();
+            };
+            function validate(
+                dev: GPUDevice,
+                serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer,
+                tables: ArrayBufferTables<Ts>,
+                params: Params,
+                expected: { buffer: ArrayBuffer },
+                elements: Uint32Array | number
+            ) {
+                const R = GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
+                const M = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
+                const enc = dev.createCommandEncoder();
+                const pBytes = serializeParameters(params);
+                const paramB = dev.createBuffer({
+                    size: pBytes.byteLength,
+                    usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
+                    label: 'validate params',
+                });
+                dev.queue.writeBuffer(paramB, 0, pBytes);
+                const inputs: GPUBuffer[] = [];
+
+                const tableBuffers: BufferTables<Ts> = mapValues(
+                    tables,
+                    (table: Record<string, { buffer: ArrayBuffer }>) =>
+                        mapValues(table, (column: { buffer: ArrayBuffer }) => {
+                            const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
+                            dev.queue.writeBuffer(buf, 0, column.buffer);
+                            inputs.push(buf);
+                            return buf;
+                        })
+                ) as BufferTables<Ts>; // TS cant tell, mapValues I think does erase the info...
+
+                const rowCount: number = elements instanceof Uint32Array ? elements.length : elements;
+                let elemBuffer: GPUBuffer | undefined;
+                if (elements instanceof Uint32Array) {
+                    elemBuffer = dev.createBuffer({ size: elements.buffer.byteLength, usage: R });
+                    dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
+                }
+                const resultsCounter = dev.createBuffer({ size: 16, usage: R });
+                const resolveCount = dev.createBuffer({ size: 16, usage: M });
+                const results = dev.createBuffer({ size: rowCount * 32, usage: R });
+                const resolve = dev.createBuffer({ size: rowCount * 32, usage: M });
+                // very awkward a bit longwinded, and there are some TS issues, but its ok!
+                if (indexed) {
+                    const iArgs: RunIndexedFilterArgs<Ts> = {
+                        enc,
+                        parameters: paramB,
+                        sets: [
+                            {
+                                elements: elemBuffer!,
+                                resultCounter: resultsCounter,
+                                results,
+                                rowCount,
+                                tables: tableBuffers,
+                            },
+                        ],
+                    };
+                    (runner as (args: RunIndexedFilterArgs<Ts>) => void)(iArgs);
+                } else {
+                    const args: RunFilterArgs<Ts> = {
+                        enc,
+                        parameters: paramB,
+                        sets: [
+                            {
+                                resultCounter: resultsCounter,
+                                results,
+                                rowCount,
+                                tables: tableBuffers,
+                            },
+                        ],
+                    };
+                    (runner as (args: RunFilterArgs<Ts>) => void)(args);
+                }
+                enc.copyBufferToBuffer(results, resolve);
+                enc.copyBufferToBuffer(resultsCounter, resolveCount);
+                dev.queue.submit([enc.finish()]);
+                // ok now get the results and compare them!
+                Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)])
+                    .then(() => {
+                        const count = new Uint32Array(resolveCount.getMappedRange());
+                        const recvd = resolve.getMappedRange();
+                        // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
+                        // if(count[0]!==expected)
+                        const dv = new DataView(recvd);
+                        const ex = new DataView(expected.buffer);
+                        let failBytes = 0;
+                        for (let i = 0; i < expected.buffer.byteLength; i++) {
+                            if (dv.getUint8(i) !== ex.getUint8(i)) {
+                                console.error('filter validation failed at byte: ', i);
+                                failBytes += 1;
+                            }
+                        }
+                        if (failBytes === 0) {
+                            console.log('validation success');
+                        }
+                    })
+                    .finally(() => {
+                        // destroy all things
+                        [resolve, resolveCount, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
+                        if (elemBuffer) {
+                            elemBuffer.destroy();
+                        }
+                    });
+            }
 
             return { runner, validate };
         };
@@ -429,7 +433,7 @@ class Selection<Ts extends Tables,From extends keyof Ts> {
                     unis.set(parameters);
                     return unis.arrayBuffer;
                 };
-                const {runner,validate} = makeRunner({
+                const { runner, validate } = makeRunner({
                     device,
                     indexed: false,
                     label,
@@ -440,11 +444,11 @@ class Selection<Ts extends Tables,From extends keyof Ts> {
                     wgSize: WG_SIZE,
                 });
                 return {
-                  run: runner,
-                  validate,
-                  serializeParameters,
-                  pipeline: pipe,
-                  parameterTypeDef: uniDef,
+                    run: runner,
+                    validate,
+                    serializeParameters,
+                    pipeline: pipe,
+                    parameterTypeDef: uniDef,
                     // validate:partial(validate,false) // todo fix validate
                 };
             },
@@ -469,7 +473,7 @@ class Selection<Ts extends Tables,From extends keyof Ts> {
                     unis.set(parameters);
                     return unis.arrayBuffer;
                 };
-                const {runner,validate} = makeRunner({
+                const { runner, validate } = makeRunner({
                     device,
                     indexed: true,
                     label,
@@ -481,11 +485,11 @@ class Selection<Ts extends Tables,From extends keyof Ts> {
                 });
 
                 return {
-                  run: runner,
-                  validate,
-                  serializeParameters,
-                  pipeline: pipe,
-                  parameterTypeDef: uniDef,
+                    run: runner,
+                    validate,
+                    serializeParameters,
+                    pipeline: pipe,
+                    parameterTypeDef: uniDef,
                     // validate:partial(validate,true)
                 };
             },
@@ -494,17 +498,16 @@ class Selection<Ts extends Tables,From extends keyof Ts> {
 }
 
 export function given<Ts extends Tables>(tables: Ts) {
-
-  function any<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
-      lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
-      op: L extends ScalarType ? OP : VOP,
-      rhs: onlyLetters<P>
-  ) {
-      return new Clause<{ [k in P]: TsType<L> }>(tables,[predicate(lhs, op, rhs)]);
-  }
-  function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
-      return new AndGroup<Params>([clause]);
-  }
+    function any<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
+        lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
+        op: L extends ScalarType ? OP : VOP,
+        rhs: onlyLetters<P>
+    ) {
+        return new Clause<{ [k in P]: TsType<L> }>(tables, [predicate(lhs, op, rhs)]);
+    }
+    function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
+        return new AndGroup<Params>([clause]);
+    }
     return {
         from: <From extends keyof Ts>(from: From) => {
             function column<E extends SwizzleExpr<Ts, From, keyof Ts[From]>>(
@@ -549,8 +552,8 @@ export function given<Ts extends Tables>(tables: Ts) {
                 selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
             ) {
                 const s = selection === '$index' ? 'tmp - 1' : toWgsl(selection, 'tmp - 1', '');
-                const type = determineType(tables,selection);
-                return new Selection(tables,from,[{ selection: s, type }]);
+                const type = determineType(tables, selection);
+                return new Selection(tables, from, [{ selection: s, type }]);
             }
 
             return { column, table, any, all, clause: any, select };

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -473,7 +473,10 @@ export function given<Ts extends Tables>(tables: Ts) {
     }
     // these are fun...  they do belong in types.ts, but moving them there means they no longer directly deal with Ts
     // I think that discconnect pushes TS over the edge and they end up not working - everything turns to unknown
+
+    /* oxlint-disable typescript/no-explicit-any */
     type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
+
     type ExpandTableColumn<T extends keyof Ts, F extends keyof Ts[T]> = F extends string ? vKeys<Ts[T], F> & T : never;
     type ExpandTableVectors<T extends keyof Ts> = keyof Ts[T] extends string
         ? UnionToIntersection<ExpandTableColumn<T, keyof Ts[T]>>

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -28,8 +28,10 @@ import type {
     ArrayBufferTables,
 } from './types';
 import * as lo from 'lodash';
+import { logger } from '~/src/logger';
 const { mapValues } = lo;
 
+/* oxlint-disable no-console, typescript/no-explicit-any*/
 const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
 
 function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
@@ -68,8 +70,8 @@ class Clause<Params extends Record<string, string | number | number[]>> {
 }
 
 class AndGroup<Params extends Record<string, string | number | number[]>> {
-    ands: Clause<Record<string, any>>[];
-    constructor(clauses: Clause<Record<string, any>>[]) {
+    ands: Clause<Parameters>[];
+    constructor(clauses: Clause<Parameters>[]) {
         this.ands = clauses;
     }
     and<GroupParams extends Record<string, string | number | number[]>>(clause: Clause<GroupParams>) {
@@ -102,7 +104,7 @@ function setupExprBuilder(from: string) {
             case 'table at field':
                 const subExpr =
                     typeof ast.atExpr === 'string'
-                        ? `[${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: undefined as any }, indexing, uniName)}]`
+                        ? `[${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: 'u32' }, indexing, uniName)}]`
                         : `[${toWgsl(ast.atExpr, indexing, uniName)}]`;
                 const [column, swizzle] = ast.field.split('.');
                 const sel: string = `${ast.table}_${column}${subExpr}`;
@@ -172,7 +174,7 @@ function mapTablesToBindings<Ts extends Tables>(
                 if (b) {
                     return { resource: buffer as GPUBuffer, binding: b };
                 }
-                console.log('omit ', name, field, ' its not referenced!');
+                // console.log('omit ', name, field, ' its not referenced!');
                 return undefined;
             });
         })
@@ -375,12 +377,12 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                         let failBytes = 0;
                         for (let i = 0; i < expected.buffer.byteLength; i++) {
                             if (dv.getUint8(i) !== ex.getUint8(i)) {
-                                console.error('filter validation failed at byte: ', i);
+                                logger.error('filter validation failed at byte: ', i);
                                 failBytes += 1;
                             }
                         }
                         if (failBytes === 0) {
-                            console.log('validation success');
+                            logger.info('validation success');
                         }
                     })
                     .finally(() => {
@@ -521,8 +523,9 @@ export function given<Ts extends Tables>(tables: Ts) {
                     kind: 'from field',
                     from: from as string,
                     field: k,
-                    type: undefined as unknown as any,
-                } as any;
+                  type: undefined as unknown as WgslType,
+                  /* oxlint-disabletypescript/no-explicit-any */
+                } as unknown as any
             }
             function table<Other extends Exclude<keyof Ts, From>>(t: Other) {
                 return {

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -371,16 +371,12 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                         const copy = new Uint8Array(dv.buffer.byteLength);
                         copy.set(new Uint8Array(dv.buffer));
                         const ex = new DataView(expected.buffer);
-                        let failBytes = 0;
                         for (let i = 0; i < expected.buffer.byteLength; i++) {
                             if (dv.getUint8(i) !== ex.getUint8(i)) {
-                                failBytes += 1;
+                              return { status: 'failure', result: copy } as const;
                             }
                         }
-                        if (failBytes === 0) {
-                            return { status: 'success' } as const;
-                        }
-                        return { status: 'failure', result: copy } as const;
+                        return { status: 'success' } as const;
                     })
                     .finally(() => {
                         // destroy all things

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -25,14 +25,486 @@ import type {
     onlyLetters,
     FType,
     Cmp,
-    BTables,
+    ArrayBufferTables,
 } from './types';
 import * as lo from 'lodash';
 const { mapValues } = lo;
 
 const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
 
+function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
+    lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
+    op: L extends ScalarType ? OP : VOP,
+    rhs: onlyLetters<P>
+) {
+    return {
+        kind: 'predicate',
+        lhs,
+        op,
+        rhs,
+    } as const;
+}
+class Clause<Params extends Record<string, string | number | number[]>> {
+    predicates: Array<PExpr<`${alpha}${string}`>>;
+    constructor(readonly tables:Tables, preds: Array<ReturnType<typeof predicate<VLen, WgslType, `${alpha}${string}`>>>) {
+        this.predicates = preds;
+    }
+    or<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
+        lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
+        op: L extends ScalarType ? OP : VOP,
+        rhs: onlyLetters<P>
+    ) {
+        return new Clause<Params & { [k in P]: TsType<L> }>(this.tables,[...this.predicates, predicate(lhs, op, rhs)]);
+    }
+    paramDeclarations() {
+        return this.predicates.reduce(
+            (acc, p) => ({ ...acc, [p.rhs]: determineType(this.tables,p.lhs) }),
+            {} as Record<string, string>
+        );
+    }
+}
+
+class AndGroup<Params extends Record<string, string | number | number[]>> {
+    ands: Clause<Record<string, any>>[];
+    constructor(clauses: Clause<Record<string, any>>[]) {
+        this.ands = clauses;
+    }
+    and<GroupParams extends Record<string, string | number | number[]>>(clause: Clause<GroupParams>) {
+        return new AndGroup<GroupParams & Params>([...this.ands, clause]);
+    }
+    paramDeclarations() {
+        return this.ands.reduce(
+            (acc, clause) => ({ ...acc, ...clause.paramDeclarations() }),
+            {} as Record<string, string>
+        );
+    }
+}
+
+function isVecOp(s: OP | VOP): s is VOP {
+    return s.startsWith('a');
+}
+function parseVecOp(op: VOP) {
+    const aggregation = op.substring(0, 3);
+    const sop = op.substring(4).split(')')[0];
+    return [aggregation, sop] as ['any' | 'all', OP];
+}
+
+function setupExprBuilder(from:string) {
+  function toWgsl(ast: AST, indexing: string, uniName: string): string {
+      switch (ast.kind) {
+          case 'from field': {
+              const [column, swizzle] = ast.field.split('.');
+              return swizzle
+                  ? `${ast.from}_${column}[${indexing}].${swizzle}`
+                  : `${ast.from}_${column}[${indexing}]`;
+          }
+          case 'table at field':
+              const subExpr =
+                  typeof ast.atExpr === 'string'
+                      ? `[${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: undefined as any }, indexing, uniName)}]`
+                      : `[${toWgsl(ast.atExpr, indexing, uniName)}]`;
+              const [column, swizzle] = ast.field.split('.');
+              const sel: string = `${ast.table}_${column}${subExpr}`;
+              return swizzle ? `${sel}.${swizzle}` : sel;
+          case 'predicate':
+              const { lhs, op, rhs } = ast;
+              if (isVecOp(op)) {
+                  const [agg, sop] = parseVecOp(op);
+                  return `${agg}(${toWgsl(lhs, indexing, uniName)} ${sop} ${uniName}.${rhs})`;
+              }
+              return `${toWgsl(lhs, indexing, uniName)} ${op} ${uniName}.${rhs}`;
+      }
+  }
+  return toWgsl;
+}
+
+function compilePredicate<Params extends Record<string, string | number | number[]>>(
+    toWgsl: ReturnType<typeof setupExprBuilder>,
+    group: AndGroup<Params> | Clause<Params>,
+    uniName: string
+) {
+    return group instanceof AndGroup
+        ? group.ands
+              .flatMap((c) => `(${c.predicates.flatMap((p) => toWgsl(p, 'element', uniName)).join(' || ')})`)
+              .join(' && ')
+        : group.predicates.flatMap((p) => toWgsl(p, 'element', uniName)).join(' || ');
+}
+function componentType(t: WgslType): ScalarType {
+    if (t.startsWith('vec')) {
+        const abbr = t.substring(4);
+        switch (abbr) {
+            case 'u':
+                return 'u32';
+            case 'i':
+                return 'i32';
+            case 'f':
+                return 'f32';
+        }
+    }
+    return t as ScalarType;
+}
+function determineType(
+    tables:Tables,
+    expr: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
+): WgslType {
+    if (expr === '$index') return 'u32';
+    switch (expr.kind) {
+        case 'from field': {
+            const [field, swizzle] = expr.field.split('.');
+            return swizzle ? componentType(tables[expr.from]![field!]!) : tables[expr.from]![field!]!;
+        }
+        case 'table at field': {
+            const [field, swizzle] = expr.field.split('.');
+            return swizzle ? componentType(tables[expr.table]![field!]!) : tables[expr.table]![field!]!;
+        }
+    }
+}
+function mapTablesToBindings<Ts extends Tables>(
+    tables: BufferTables<Ts>,
+    lookups: Record<string, Record<string, number>>
+):{resource:GPUBuffer,binding:number}[]
+{
+  return entries(tables)
+        .flatMap(([name, table]) => {
+            return entries(table).map(([field, buffer]) => {
+                // I promise, these are all strings, its ok
+                const b = lookups[name as string]?.[field as string];
+                if (b) {
+                    return { resource: buffer as GPUBuffer, binding: b };
+                }
+                console.log('omit ', name, field, ' its not referenced!');
+                return undefined;
+            });
+        })
+        .filter((x) => x !== undefined);
+}
+class Selection<Ts extends Tables,From extends keyof Ts> {
+  selections: ReadonlyArray<Sel>;
+  toWgsl: ReturnType<typeof setupExprBuilder>;
+    constructor(readonly tables:Ts,readonly from:From, selections: ReadonlyArray<Sel>) {
+      this.selections = selections;
+      this.toWgsl = setupExprBuilder(this.from as string);
+    }
+    select(
+        selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
+    ) {
+        const s = selection === '$index' ? 'tmp - 1' : this.toWgsl(selection, 'tmp - 1', ''); // uni-name not relavant in selection...
+        const type = determineType(this.tables,selection);
+        return new Selection(this.tables,this.from,[...this.selections, { selection: s, type }]);
+    }
+    where<Params extends Parameters>(predicates: AndGroup<Params> | Clause<Params>) {
+        // constants //
+
+        const START_BINDING = 3;
+        const UNI_INSTANCE_NAME = 'params';
+        const UNI_STRUCT_TYPE_NAME = 'Params';
+        const WG_SIZE = 64;
+        const paramTypes = predicates.paramDeclarations();
+        const paramDecls = entries(paramTypes)
+            .map(([name, type]) => `${name}:${type}`)
+            .join(',\n');
+        // const uniDecl = `struct ${UNI_STRUCT_NAME} {
+        //   ${paramDecls}
+      //   };`
+      const { tables } = this;
+        const predicateExpr = `(${compilePredicate(this.toWgsl,predicates, UNI_INSTANCE_NAME)})`;
+        let binding = START_BINDING;
+        let columnBindings: Record<string, Record<string, number>> = {};
+        // associate a binding with every field of every table
+        for (const t of Object.keys(tables)) {
+            columnBindings[t] = {};
+            for (const col of Object.keys(tables[t]!)) {
+                columnBindings[t]![col] = binding;
+                binding += 1;
+            }
+        }
+      const makeRunner = <Indexed extends boolean>(options: {
+        device: GPUDevice;
+        pipe: ReturnType<typeof buildFilterPipeline>;
+        shader: string;
+        safeLookups: Record<string, Record<string, number>>;
+        indexed: Indexed;
+        label: string;
+        wgSize: number;
+        serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer;
+      }) => {
+        const { device, pipe, safeLookups, indexed, label, wgSize } = options;
+        const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
+          const { enc, parameters, sets, timestampWrites } = args;
+          // here, we zero out the result counters
+          // TODO - consider not doing this - if we didnt do that:
+          // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
+          // 2. we technically could invoke this whole thing in an open compute pass...? right?
+          args.sets.forEach((s) => {
+            device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
+          });
+          const bindings = indexed
+            ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
+              return device.createBindGroup({
+                layout: pipe.pipeline.getBindGroupLayout(1),
+                entries: [
+                  { binding: 0, resource: s.resultCounter },
+                  { binding: 1, resource: s.results },
+                  { binding: 2, resource: s.elements },
+                  ...mapTablesToBindings(s.tables, safeLookups),
+                ],
+              });
+            })
+            : args.sets.map((s, i) => {
+              return device.createBindGroup({
+                layout: pipe.pipeline.getBindGroupLayout(1),
+                entries: [
+                  { binding: 0, resource: s.resultCounter },
+                  { binding: 1, resource: s.results },
+                  ...mapTablesToBindings(s.tables, safeLookups),
+                ],
+              });
+            });
+
+          const bg0 = device.createBindGroup({
+            layout: pipe.pipeline.getBindGroupLayout(0),
+            entries: [{ binding: 0, resource: parameters }],
+          });
+
+          const pass = enc.beginComputePass(
+            timestampWrites
+              ? {
+                label,
+                timestampWrites,
+              }
+              : { label }
+          );
+          pass.setPipeline(pipe.pipeline);
+          pass.setBindGroup(0, bg0);
+          for (let i = 0; i < sets.length; i++) {
+            const s = sets[i]!;
+            const bg1 = bindings[i]!;
+            // console.log('running filter-->',s.results.label)
+            pass.setBindGroup(1, bg1);
+            const dispatchCount = Math.ceil(s.rowCount / wgSize);
+            pass.dispatchWorkgroups(dispatchCount);
+          }
+          pass.end();
+        };
+        function validate(
+          dev: GPUDevice,
+          serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer,
+          tables: ArrayBufferTables<Ts>,
+          params: Params,
+          expected: { buffer: ArrayBuffer },
+          elements: Uint32Array | number
+        ) {
+          const R = GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
+          const M = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
+          const enc = dev.createCommandEncoder();
+          const pBytes = serializeParameters(params);
+          const paramB = dev.createBuffer({
+            size: pBytes.byteLength,
+            usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
+            label: 'validate params',
+          });
+          dev.queue.writeBuffer(paramB, 0, pBytes);
+          const inputs: GPUBuffer[] = [];
+
+          const tableBuffers: BufferTables<Ts> = mapValues(tables, (table: Record<string, { buffer: ArrayBuffer }>) =>
+            mapValues(table, (column: { buffer: ArrayBuffer }) => {
+              const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
+              dev.queue.writeBuffer(buf, 0, column.buffer);
+              inputs.push(buf);
+              return buf;
+            })
+          ) as BufferTables<Ts>; // TS cant tell, mapValues I think does erase the info...
+
+          const rowCount: number = elements instanceof Uint32Array ? elements.length : elements;
+          let elemBuffer: GPUBuffer | undefined;
+          if (elements instanceof Uint32Array) {
+            elemBuffer = dev.createBuffer({ size: elements.buffer.byteLength, usage: R });
+            dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
+          }
+          const resultsCounter = dev.createBuffer({ size: 16, usage: R });
+          const resolveCount = dev.createBuffer({ size: 16, usage: M });
+          const results = dev.createBuffer({ size: rowCount * 32, usage: R });
+          const resolve = dev.createBuffer({ size: rowCount * 32, usage: M });
+          // very awkward a bit longwinded, and there are some TS issues, but its ok!
+          if (indexed) {
+            const iArgs: RunIndexedFilterArgs<Ts> = {
+              enc,
+              parameters: paramB,
+              sets: [
+                {
+                  elements: elemBuffer!,
+                  resultCounter: resultsCounter,
+                  results,
+                  rowCount,
+                  tables: tableBuffers,
+                },
+              ],
+            };
+            (runner as (args: RunIndexedFilterArgs<Ts>) => void)(iArgs);
+          } else {
+            const args: RunFilterArgs<Ts> = {
+              enc,
+              parameters: paramB,
+              sets: [
+                {
+                  resultCounter: resultsCounter,
+                  results,
+                  rowCount,
+                  tables: tableBuffers,
+                },
+              ],
+            };
+            (runner as (args: RunFilterArgs<Ts>) => void)(args);
+          }
+          enc.copyBufferToBuffer(results, resolve);
+          enc.copyBufferToBuffer(resultsCounter, resolveCount);
+          dev.queue.submit([enc.finish()]);
+          // ok now get the results and compare them!
+          Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)])
+            .then(() => {
+              const count = new Uint32Array(resolveCount.getMappedRange());
+              const recvd = resolve.getMappedRange();
+              // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
+              // if(count[0]!==expected)
+              const dv = new DataView(recvd);
+              const ex = new DataView(expected.buffer);
+              let failBytes = 0;
+              for (let i = 0; i < expected.buffer.byteLength; i++) {
+                if (dv.getUint8(i) !== ex.getUint8(i)) {
+                  console.error('filter validation failed at byte: ', i);
+                  failBytes += 1;
+                }
+              }
+              if (failBytes === 0) {
+                console.log('validation success');
+              }
+            })
+            .finally(() => {
+              // destroy all things
+              [resolve, resolveCount, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
+              if (elemBuffer) {
+                elemBuffer.destroy();
+              }
+            });
+        }
+
+            return { runner, validate };
+        };
+
+        return {
+            shaderOnly: () => {
+                const Q = assembleQuery(
+                    {
+                        from: this.from as string,
+                        selections: this.selections,
+                        tables,
+                        uniformName: UNI_INSTANCE_NAME,
+                        uniformTypeName: 'Params',
+                    },
+                    predicateExpr,
+                    paramDecls,
+                    64,
+                    false
+                );
+                return Q.shader;
+            },
+            build: (device: GPUDevice, label: string) => {
+                const Q = assembleQuery(
+                    {
+                        from: this.from as string,
+                        selections: this.selections,
+                        tables,
+                        uniformName: UNI_INSTANCE_NAME,
+                        uniformTypeName: UNI_STRUCT_TYPE_NAME,
+                    },
+                    predicateExpr,
+                    paramDecls,
+                    64,
+                    false
+                );
+                const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+                const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+                const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+                    const unis = wgh.makeStructuredView(uniDef, buffer);
+                    unis.set(parameters);
+                    return unis.arrayBuffer;
+                };
+                const {runner,validate} = makeRunner({
+                    device,
+                    indexed: false,
+                    label,
+                    pipe,
+                    safeLookups: columnBindings,
+                    serializeParameters,
+                    shader: Q.shader,
+                    wgSize: WG_SIZE,
+                });
+                return {
+                  run: runner,
+                  validate,
+                  serializeParameters,
+                  pipeline: pipe,
+                  parameterTypeDef: uniDef,
+                    // validate:partial(validate,false) // todo fix validate
+                };
+            },
+            buildIndexed: (device: GPUDevice, label: string) => {
+                const Q = assembleQuery(
+                    {
+                        from: this.from as string,
+                        selections: this.selections,
+                        tables,
+                        uniformName: UNI_INSTANCE_NAME,
+                        uniformTypeName: 'Params',
+                    },
+                    predicateExpr,
+                    paramDecls,
+                    64,
+                    true
+                );
+                const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+                const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+                const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+                    const unis = wgh.makeStructuredView(uniDef, buffer);
+                    unis.set(parameters);
+                    return unis.arrayBuffer;
+                };
+                const {runner,validate} = makeRunner({
+                    device,
+                    indexed: true,
+                    label,
+                    pipe,
+                    safeLookups: columnBindings,
+                    serializeParameters,
+                    shader: Q.shader,
+                    wgSize: WG_SIZE,
+                });
+
+                return {
+                  run: runner,
+                  validate,
+                  serializeParameters,
+                  pipeline: pipe,
+                  parameterTypeDef: uniDef,
+                    // validate:partial(validate,true)
+                };
+            },
+        };
+    }
+}
+
 export function given<Ts extends Tables>(tables: Ts) {
+
+  function any<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
+      lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
+      op: L extends ScalarType ? OP : VOP,
+      rhs: onlyLetters<P>
+  ) {
+      return new Clause<{ [k in P]: TsType<L> }>(tables,[predicate(lhs, op, rhs)]);
+  }
+  function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
+      return new AndGroup<Params>([clause]);
+  }
     return {
         from: <From extends keyof Ts>(from: From) => {
             function column<E extends SwizzleExpr<Ts, From, keyof Ts[From]>>(
@@ -71,370 +543,14 @@ export function given<Ts extends Tables>(tables: Ts) {
                     },
                 };
             }
-            function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
-                lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
-                op: L extends ScalarType ? OP : VOP,
-                rhs: onlyLetters<P>
-            ) {
-                return {
-                    kind: 'predicate',
-                    lhs,
-                    op,
-                    rhs,
-                } as const;
-            }
-            class Clause<Params extends Record<string, string | number | number[]>> {
-                predicates: Array<PExpr<`${alpha}${string}`>>;
-                constructor(preds: Array<ReturnType<typeof predicate<VLen, WgslType, `${alpha}${string}`>>>) {
-                    this.predicates = preds;
-                }
-                or<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
-                    lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
-                    op: L extends ScalarType ? OP : VOP,
-                    rhs: onlyLetters<P>
-                ) {
-                    return new Clause<Params & { [k in P]: TsType<L> }>([...this.predicates, predicate(lhs, op, rhs)]);
-                }
-                paramDeclarations() {
-                    return this.predicates.reduce(
-                        (acc, p) => ({ ...acc, [p.rhs]: determineType(p.lhs) }),
-                        {} as Record<string, string>
-                    );
-                }
-                // finish(params: Params) {
 
-                // }
-            }
-
-            function any<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
-                lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
-                op: L extends ScalarType ? OP : VOP,
-                rhs: onlyLetters<P>
-            ) {
-                return new Clause<{ [k in P]: TsType<L> }>([predicate(lhs, op, rhs)]);
-            }
-            class AndGroup<Params extends Record<string, string | number | number[]>> {
-                ands: Clause<Record<string, any>>[];
-                constructor(clauses: Clause<Record<string, any>>[]) {
-                    this.ands = clauses;
-                }
-                and<GroupParams extends Record<string, string | number | number[]>>(clause: Clause<GroupParams>) {
-                    return new AndGroup<GroupParams & Params>([...this.ands, clause]);
-                }
-                paramDeclarations() {
-                    return this.ands.reduce(
-                        (acc, clause) => ({ ...acc, ...clause.paramDeclarations() }),
-                        {} as Record<string, string>
-                    );
-                }
-                // finish(params: Params) {
-
-                // }
-            }
-            function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
-                return new AndGroup<Params>([clause]);
-            }
-            function isVecOp(s: OP | VOP): s is VOP {
-                return s.startsWith('a');
-            }
-            function parseVecOp(op: VOP) {
-                const aggregation = op.substring(0, 3);
-                const sop = op.substring(4).split(')')[0];
-                return [aggregation, sop] as ['any' | 'all', OP];
-            }
-            function compy(ast: AST, indexing: string, uniName: string): string {
-                switch (ast.kind) {
-                    case 'from field': {
-                        const [column, swizzle] = ast.field.split('.');
-                        return swizzle
-                            ? `${ast.from}_${column}[${indexing}].${swizzle}`
-                            : `${ast.from}_${column}[${indexing}]`;
-                    }
-                    case 'table at field':
-                        const subExpr =
-                            typeof ast.atExpr === 'string'
-                                ? `[${compy({ kind: 'from field', field: ast.atExpr, from: from as string, type: undefined as any }, indexing, uniName)}]`
-                                : `[${compy(ast.atExpr, indexing, uniName)}]`;
-                        const [column, swizzle] = ast.field.split('.');
-                        const sel: string = `${ast.table}_${column}${subExpr}`;
-                        return swizzle ? `${sel}.${swizzle}` : sel;
-                    case 'predicate':
-                        const { lhs, op, rhs } = ast;
-                        if (isVecOp(op)) {
-                            const [agg, sop] = parseVecOp(op);
-                            return `${agg}(${compy(lhs, indexing, uniName)} ${sop} ${uniName}.${rhs})`;
-                        }
-                        return `${compy(lhs, indexing, uniName)} ${op} ${uniName}.${rhs}`;
-                }
-            }
-            function compilePredicate<Params extends Record<string, string | number | number[]>>(
-                group: AndGroup<Params> | Clause<Params>,
-                uniName: string
-            ) {
-                return group instanceof AndGroup
-                    ? group.ands
-                          .flatMap((c) => `(${c.predicates.flatMap((p) => compy(p, 'element', uniName)).join(' || ')})`)
-                          .join(' && ')
-                    : group.predicates.flatMap((p) => compy(p, 'element', uniName)).join(' || ');
-            }
-            function componentType(t: WgslType): ScalarType {
-                if (t.startsWith('vec')) {
-                    const abbr = t.substring(4);
-                    switch (abbr) {
-                        case 'u':
-                            return 'u32';
-                        case 'i':
-                            return 'i32';
-                        case 'f':
-                            return 'f32';
-                    }
-                }
-                return t as ScalarType;
-            }
-            function determineType(
-                expr: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
-            ): WgslType {
-                if (expr === '$index') return 'u32';
-                switch (expr.kind) {
-                    case 'from field': {
-                        const [field, swizzle] = expr.field.split('.');
-                        return swizzle ? componentType(tables[expr.from]![field!]!) : tables[expr.from]![field!]!;
-                    }
-                    case 'table at field': {
-                        const [field, swizzle] = expr.field.split('.');
-                        return swizzle ? componentType(tables[expr.table]![field!]!) : tables[expr.table]![field!]!;
-                    }
-                }
-            }
-            function mapTablesToBindings<Ts extends Tables>(
-                tables: BufferTables<Ts>,
-                lookups: Record<string, Record<string, number>>
-            ) {
-                return entries(tables)
-                    .flatMap(([name, table]) => {
-                        return entries(table).map(([field, buffer]) => {
-                            // I promise, these are all strings, its ok
-                            const b = lookups[name as string]?.[field as string];
-                            if (b) {
-                                return { resource: buffer, binding: b };
-                            }
-                            console.log('omit ', name, field, ' its not referenced!');
-                            return undefined;
-                        });
-                    })
-                    .filter((x) => x !== undefined);
-            }
-            class Selection {
-                selections: ReadonlyArray<Sel>;
-                constructor(selections: ReadonlyArray<Sel>) {
-                    this.selections = selections;
-                }
-                select(
-                    selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
-                ) {
-                    const s = selection === '$index' ? 'tmp - 1' : compy(selection, 'tmp - 1', ''); // uni-name not relavant in selection...
-                    const type = determineType(selection);
-                    return new Selection([...this.selections, { selection: s, type }]);
-                }
-                where<Params extends Parameters>(predicates: AndGroup<Params> | Clause<Params>) {
-                    // constants //
-                    const START_BINDING = 3;
-                    const UNI_INSTANCE_NAME = 'params';
-                    const UNI_STRUCT_TYPE_NAME = 'Params';
-                    const WG_SIZE = 64;
-                    const paramTypes = predicates.paramDeclarations();
-                    const paramDecls = entries(paramTypes)
-                        .map(([name, type]) => `${name}:${type}`)
-                        .join(',\n');
-                    // const uniDecl = `struct ${UNI_STRUCT_NAME} {
-                    //   ${paramDecls}
-                    //   };`
-                    const predicateExpr = `(${compilePredicate(predicates, UNI_INSTANCE_NAME)})`;
-                    let binding = START_BINDING;
-                    let columnBindings: Record<string, Record<string, number>> = {};
-                    // associate a binding with every field of every table
-                    for (const t of Object.keys(tables)) {
-                        columnBindings[t] = {};
-                        for (const col of Object.keys(tables[t]!)) {
-                            columnBindings[t]![col] = binding;
-                            binding += 1;
-                        }
-                    }
-                    const makeRunner = <Indexed extends boolean>(options: {
-                        device: GPUDevice;
-                        pipe: ReturnType<typeof buildFilterPipeline>;
-                        shader: string;
-                        safeLookups: Record<string, Record<string, number>>;
-                        indexed: Indexed;
-                        label: string;
-                        wgSize: number;
-                        serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer;
-                    }) => {
-                        const { device, pipe, safeLookups, indexed, label, wgSize } = options;
-                        const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
-                            const { enc, parameters, sets, timestampWrites } = args;
-                            // here, we zero out the result counters
-                            // TODO - consider not doing this - if we didnt do that:
-                            // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
-                            // 2. we technically could invoke this whole thing in an open compute pass...? right?
-                            args.sets.forEach((s) => {
-                                device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
-                            });
-                            const bindings = indexed
-                                ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
-                                      return device.createBindGroup({
-                                          layout: pipe.pipeline.getBindGroupLayout(1),
-                                          entries: [
-                                              { binding: 0, resource: s.resultCounter },
-                                              { binding: 1, resource: s.results },
-                                              { binding: 2, resource: s.elements },
-                                              ...mapTablesToBindings(s.tables, safeLookups),
-                                          ],
-                                      });
-                                  })
-                                : args.sets.map((s, i) => {
-                                      return device.createBindGroup({
-                                          layout: pipe.pipeline.getBindGroupLayout(1),
-                                          entries: [
-                                              { binding: 0, resource: s.resultCounter },
-                                              { binding: 1, resource: s.results },
-                                              ...mapTablesToBindings(s.tables, safeLookups),
-                                          ],
-                                      });
-                                  });
-
-                            const bg0 = device.createBindGroup({
-                                layout: pipe.pipeline.getBindGroupLayout(0),
-                                entries: [{ binding: 0, resource: parameters }],
-                            });
-
-                            const pass = enc.beginComputePass(
-                                timestampWrites
-                                    ? {
-                                          label,
-                                          timestampWrites,
-                                      }
-                                    : { label }
-                            );
-                            pass.setPipeline(pipe.pipeline);
-                            pass.setBindGroup(0, bg0);
-                            for (let i = 0; i < sets.length; i++) {
-                                const s = sets[i]!;
-                                const bg1 = bindings[i]!;
-                                // console.log('running filter-->',s.results.label)
-                                pass.setBindGroup(1, bg1);
-                                const dispatchCount = Math.ceil(s.rowCount / wgSize);
-                                pass.dispatchWorkgroups(dispatchCount);
-                            }
-                            pass.end();
-                        };
-                        return runner;
-                    };
-
-                    return {
-                        shaderOnly: () => {
-                            const Q = assembleQuery(
-                                {
-                                    from: from as string,
-                                    selections: this.selections,
-                                    tables,
-                                    uniformName: UNI_INSTANCE_NAME,
-                                    uniformTypeName: 'Params',
-                                },
-                                predicateExpr,
-                                paramDecls,
-                                64,
-                                false
-                            );
-                            return Q.shader;
-                        },
-                        build: (device: GPUDevice, label: string) => {
-                            const Q = assembleQuery(
-                                {
-                                    from: from as string,
-                                    selections: this.selections,
-                                    tables,
-                                    uniformName: UNI_INSTANCE_NAME,
-                                    uniformTypeName: UNI_STRUCT_TYPE_NAME,
-                                },
-                                predicateExpr,
-                                paramDecls,
-                                64,
-                                false
-                            );
-                            const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-                            const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
-                            const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-                                const unis = wgh.makeStructuredView(uniDef, buffer);
-                                unis.set(parameters);
-                                return unis.arrayBuffer;
-                            };
-                            const runner = makeRunner({
-                                device,
-                                indexed: false,
-                                label,
-                                pipe,
-                                safeLookups: columnBindings,
-                                serializeParameters,
-                                shader: Q.shader,
-                                wgSize: WG_SIZE,
-                            });
-                            return {
-                                run: runner,
-                                serializeParameters,
-                                pipeline: pipe,
-                                parameterTypeDef: uniDef,
-                                // validate:partial(validate,false) // todo fix validate
-                            };
-                        },
-                        buildIndexed: (device: GPUDevice, label: string) => {
-                            const Q = assembleQuery(
-                                {
-                                    from: from as string,
-                                    selections: this.selections,
-                                    tables,
-                                    uniformName: UNI_INSTANCE_NAME,
-                                    uniformTypeName: 'Params',
-                                },
-                                predicateExpr,
-                                paramDecls,
-                                64,
-                                true
-                            );
-                            const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-                            const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
-                            const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-                                const unis = wgh.makeStructuredView(uniDef, buffer);
-                                unis.set(parameters);
-                                return unis.arrayBuffer;
-                            };
-                            const runner = makeRunner({
-                                device,
-                                indexed: true,
-                                label,
-                                pipe,
-                                safeLookups: columnBindings,
-                                serializeParameters,
-                                shader: Q.shader,
-                                wgSize: WG_SIZE,
-                            });
-                            return {
-                                run: runner,
-                                serializeParameters,
-                                pipeline: pipe,
-                                parameterTypeDef: uniDef,
-                                // validate:partial(validate,true)
-                            };
-                        },
-                    };
-                }
-            }
+            const toWgsl = setupExprBuilder(from as string);
             function select(
                 selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
             ) {
-                const s = selection === '$index' ? 'tmp - 1' : compy(selection, 'tmp - 1', '');
-                const type = determineType(selection);
-                return new Selection([{ selection: s, type }]);
+                const s = selection === '$index' ? 'tmp - 1' : toWgsl(selection, 'tmp - 1', '');
+                const type = determineType(tables,selection);
+                return new Selection(tables,from,[{ selection: s, type }]);
             }
 
             return { column, table, any, all, clause: any, select };
@@ -442,92 +558,3 @@ export function given<Ts extends Tables>(tables: Ts) {
     };
 }
 type Parameters = Record<string, string | number | number[]>;
-
-// validation at runtime?
-function validate<Ts extends Tables, Params extends Parameters, Indexed extends boolean>(
-    indexed: Indexed,
-    dev: GPUDevice,
-    filter: {
-        serializeParameters: (params: Params) => ArrayBuffer;
-        run: (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => void;
-    },
-    tables: BTables<Ts, { buffer: ArrayBuffer }>,
-    params: Params,
-    expected: { buffer: ArrayBuffer },
-    elements: Uint32Array | number
-) {
-    const R = GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
-    const M = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
-    const enc = dev.createCommandEncoder();
-    const pBytes = filter.serializeParameters(params);
-    const paramB = dev.createBuffer({
-        size: pBytes.byteLength,
-        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
-        label: 'validate params',
-    });
-    dev.queue.writeBuffer(paramB, 0, pBytes);
-    const inputs: GPUBuffer[] = [];
-    Object.entries;
-    const tableBuffers = mapValues(tables, (table) =>
-        mapValues(table, (column: { buffer: ArrayBuffer }) => {
-            const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
-            dev.queue.writeBuffer(buf, 0, column.buffer);
-            inputs.push(buf);
-            return buf;
-        })
-    );
-    const rowCount: number = indexed ? (elements as Uint32Array).length : (elements as number);
-    let elemBuffer: GPUBuffer | undefined;
-    if (indexed && elements instanceof Uint32Array) {
-        elemBuffer = dev.createBuffer({ size: elements.buffer.byteLength, usage: R });
-        dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
-    }
-    const resultsCounter = dev.createBuffer({ size: 16, usage: R });
-    const resolveCount = dev.createBuffer({ size: 16, usage: M });
-    const results = dev.createBuffer({ size: rowCount * 32, usage: R });
-    const resolve = dev.createBuffer({ size: rowCount * 32, usage: M });
-    // @ts-expect-error
-    filter.run({
-        enc,
-        parameters: paramB,
-        sets: [
-            {
-                elements: elemBuffer,
-                resultCounter: resultsCounter,
-                results,
-                rowCount,
-                tables: tableBuffers,
-            },
-        ],
-    });
-    enc.copyBufferToBuffer(results, resolve);
-    enc.copyBufferToBuffer(resultsCounter, resolveCount);
-    dev.queue.submit([enc.finish()]);
-    // ok now get the results and compare them!
-    Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)])
-        .then(() => {
-            const count = new Uint32Array(resolveCount.getMappedRange());
-            const recvd = resolve.getMappedRange();
-            // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
-            // if(count[0]!==expected)
-            const dv = new DataView(recvd);
-            const ex = new DataView(expected.buffer);
-            let failBytes = 0;
-            for (let i = 0; i < expected.buffer.byteLength; i++) {
-                if (dv.getUint8(i) !== ex.getUint8(i)) {
-                    console.error('filter validation failed at byte: ', i);
-                    failBytes += 1;
-                }
-            }
-            if (failBytes === 0) {
-                console.log('validation success');
-            }
-        })
-        .finally(() => {
-            // destroy all things
-            [resolve, resolveCount, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
-            if (elemBuffer) {
-                elemBuffer.destroy();
-            }
-        });
-}

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -2,8 +2,10 @@ import { buildFilterPipeline } from "./build";
 import { assembleQuery } from "./gen";
 import * as wgh from 'webgpu-utils'
 import type { alpha,Tables,SwizzleIndexExpr, ComponentType, IndexExpr, SwizzleExpr, AST, BufferTables, ColumnExpr, OP, PExpr, RunFilterArgs, RunIndexedFilterArgs, Sel, TsType, VOP, WgslType, ScalarType, VLen, VectorType, onlyLetters, FType, Cmp, BTables,} from "./types";
-import entries from "lodash/entries";
-import mapValues from "lodash/mapValues";
+import * as lo from 'lodash'
+const { mapValues } = lo;
+
+const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
 
 export function given<Ts extends Tables>(
   tables: Ts,
@@ -160,7 +162,8 @@ export function given<Ts extends Tables>(
       function mapTablesToBindings<Ts extends Tables>(tables: BufferTables<Ts>, lookups: Record<string, Record<string, number>>) {
         return entries(tables).flatMap(([name, table]) => {
           return entries(table).map(([field, buffer]) => {
-            const b = lookups[name]?.[field];
+            // I promise, these are all strings, its ok
+            const b = lookups[name as string]?.[field as string];
             if (b) {
               return { resource: buffer, binding: b }
             }
@@ -360,7 +363,8 @@ function validate<Ts extends Tables, Params extends Parameters, Indexed extends 
     const pBytes = filter.serializeParameters(params)
     const paramB = dev.createBuffer({ size: pBytes.byteLength, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM, label: 'validate params' })
     dev.queue.writeBuffer(paramB, 0, pBytes)
-    const inputs: GPUBuffer[]=[]
+  const inputs: GPUBuffer[] = []
+    Object.entries
     const tableBuffers = mapValues(tables, (table) => mapValues(table, (column:{buffer:ArrayBuffer}) => {
         const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
         dev.queue.writeBuffer(buf, 0, column.buffer);

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -373,7 +373,7 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                         const ex = new DataView(expected.buffer);
                         for (let i = 0; i < expected.buffer.byteLength; i++) {
                             if (dv.getUint8(i) !== ex.getUint8(i)) {
-                              return { status: 'failure', result: copy } as const;
+                                return { status: 'failure', result: copy } as const;
                             }
                         }
                         return { status: 'success' } as const;

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -367,9 +367,9 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                     .mapAsync(GPUMapMode.READ)
                     .then(() => {
                         const recvd = resolve.getMappedRange();
-                      const dv = new DataView(recvd);
-                      const copy = new Uint8Array(dv.buffer.byteLength);
-                      copy.set(new Uint8Array(dv.buffer));
+                        const dv = new DataView(recvd);
+                        const copy = new Uint8Array(dv.buffer.byteLength);
+                        copy.set(new Uint8Array(dv.buffer));
                         const ex = new DataView(expected.buffer);
                         let failBytes = 0;
                         for (let i = 0; i < expected.buffer.byteLength; i++) {
@@ -377,13 +377,13 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                                 failBytes += 1;
                             }
                         }
-                      if (failBytes === 0) {
-                        return { status: 'success' } as const;
-                      }
-                      return { status: 'failure', result: copy } as const;
+                        if (failBytes === 0) {
+                            return { status: 'success' } as const;
+                        }
+                        return { status: 'failure', result: copy } as const;
                     })
                     .finally(() => {
-                      // destroy all things
+                        // destroy all things
                         resolve.unmap();
                         [resolve, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
                         if (elemBuffer) {

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -28,7 +28,6 @@ import type {
     ITable,
 } from './types';
 import * as lo from 'lodash';
-import { logger } from '~/src/logger';
 const { mapValues } = lo;
 
 const entries = <T extends {}>(r: T): ReadonlyArray<[string, T[keyof T]]> => Object.entries(r);
@@ -364,25 +363,28 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                 enc.copyBufferToBuffer(results, resolve);
                 dev.queue.submit([enc.finish()]);
                 // ok now get the results and compare them!
-                resolve
+                return resolve
                     .mapAsync(GPUMapMode.READ)
                     .then(() => {
                         const recvd = resolve.getMappedRange();
-                        const dv = new DataView(recvd);
+                      const dv = new DataView(recvd);
+                      const copy = new Uint8Array(dv.buffer.byteLength);
+                      copy.set(new Uint8Array(dv.buffer));
                         const ex = new DataView(expected.buffer);
                         let failBytes = 0;
                         for (let i = 0; i < expected.buffer.byteLength; i++) {
                             if (dv.getUint8(i) !== ex.getUint8(i)) {
-                                logger.error('filter validation failed at byte: ', i);
                                 failBytes += 1;
                             }
                         }
-                        if (failBytes === 0) {
-                            logger.info('validation success');
-                        }
+                      if (failBytes === 0) {
+                        return { status: 'success' } as const;
+                      }
+                      return { status: 'failure', result: copy } as const;
                     })
                     .finally(() => {
-                        // destroy all things
+                      // destroy all things
+                        resolve.unmap();
                         [resolve, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
                         if (elemBuffer) {
                             elemBuffer.destroy();

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -31,8 +31,7 @@ import * as lo from 'lodash';
 import { logger } from '~/src/logger';
 const { mapValues } = lo;
 
-/* oxlint-disable no-console, typescript/no-explicit-any*/
-const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
+const entries = <T extends {}>(r: T):ReadonlyArray<[string, T[keyof T]]> => Object.entries(r) ;
 
 function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
     lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
@@ -169,12 +168,10 @@ function mapTablesToBindings<Ts extends Tables>(
     return entries(tables)
         .flatMap(([name, table]) => {
             return entries(table).map(([field, buffer]) => {
-                // I promise, these are all strings, its ok
-                const b = lookups[name as string]?.[field as string];
+                const b = lookups[name]?.[field];
                 if (b) {
-                    return { resource: buffer as GPUBuffer, binding: b };
+                  return { resource: buffer as GPUBuffer, binding: b };
                 }
-                // console.log('omit ', name, field, ' its not referenced!');
                 return undefined;
             });
         })
@@ -196,6 +193,7 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
         const type = determineType(this.tables, selection);
         return new Selection(this.tables, this.from, [...this.selections, { selection: s, type }]);
     }
+
     where<Params extends Parameters>(predicates: AndGroup<Params> | Clause<Params>) {
         // constants //
 
@@ -207,11 +205,12 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
         const paramDecls = entries(paramTypes)
             .map(([name, type]) => `${name}:${type}`)
             .join(',\n');
-        // const uniDecl = `struct ${UNI_STRUCT_NAME} {
-        //   ${paramDecls}
-        //   };`
-        const { tables } = this;
-        const predicateExpr = `(${compilePredicate(this.toWgsl, predicates, UNI_INSTANCE_NAME)})`;
+
+      const { tables } = this;
+
+
+
+      const predicateExpr = `(${compilePredicate(this.toWgsl, predicates, UNI_INSTANCE_NAME)})`;
         let binding = START_BINDING;
         let columnBindings: Record<string, Record<string, number>> = {};
         // associate a binding with every field of every table
@@ -222,6 +221,7 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                 binding += 1;
             }
         }
+
         const makeRunner = <Indexed extends boolean>(options: {
             device: GPUDevice;
             pipe: ReturnType<typeof buildFilterPipeline>;
@@ -235,10 +235,8 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
             const { device, pipe, safeLookups, indexed, label, wgSize } = options;
             const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
                 const { enc, parameters, sets, timestampWrites } = args;
-                // here, we zero out the result counters
-                // TODO - consider not doing this - if we didnt do that:
-                // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
-                // 2. we technically could invoke this whole thing in an open compute pass...? right?
+
+                // zero out the result counters...
                 args.sets.forEach((s) => {
                     device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
                 });
@@ -328,7 +326,6 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                     dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
                 }
                 const resultsCounter = dev.createBuffer({ size: 16, usage: R });
-                const resolveCount = dev.createBuffer({ size: 16, usage: M });
                 const results = dev.createBuffer({ size: rowCount * 32, usage: R });
                 const resolve = dev.createBuffer({ size: rowCount * 32, usage: M });
                 // very awkward a bit longwinded, and there are some TS issues, but its ok!
@@ -363,15 +360,10 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                     (runner as (args: RunFilterArgs<Ts>) => void)(args);
                 }
                 enc.copyBufferToBuffer(results, resolve);
-                enc.copyBufferToBuffer(resultsCounter, resolveCount);
                 dev.queue.submit([enc.finish()]);
                 // ok now get the results and compare them!
-                Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)])
-                    .then(() => {
-                        const count = new Uint32Array(resolveCount.getMappedRange());
+                resolve.mapAsync(GPUMapMode.READ).then(() => {
                         const recvd = resolve.getMappedRange();
-                        // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
-                        // if(count[0]!==expected)
                         const dv = new DataView(recvd);
                         const ex = new DataView(expected.buffer);
                         let failBytes = 0;
@@ -387,7 +379,7 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                     })
                     .finally(() => {
                         // destroy all things
-                        [resolve, resolveCount, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
+                        [resolve, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
                         if (elemBuffer) {
                             elemBuffer.destroy();
                         }
@@ -396,7 +388,46 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
 
             return { runner, validate };
         };
+        const buildHelper = <Indexed extends boolean>(device: GPUDevice,label:string,indexed:Indexed) => {
+          const Q = assembleQuery(
+              {
+                  from: this.from as string,
+                  selections: this.selections,
+                  tables,
+                  uniformName: UNI_INSTANCE_NAME,
+                  uniformTypeName: UNI_STRUCT_TYPE_NAME,
+              },
+              predicateExpr,
+              paramDecls,
+              64,
+              indexed
+          );
+          const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+          const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+          const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+              const unis = wgh.makeStructuredView(uniDef, buffer);
+              unis.set(parameters);
+              return unis.arrayBuffer;
+          };
 
+          const { runner, validate } = makeRunner({
+              device,
+              indexed,
+              label,
+              pipe,
+              safeLookups: columnBindings,
+              serializeParameters,
+              shader: Q.shader,
+              wgSize: WG_SIZE,
+          });
+          return {
+              run: runner,
+              validate,
+              serializeParameters,
+              pipeline: pipe,
+              parameterTypeDef: uniDef,
+          };
+        }
         return {
             shaderOnly: () => {
                 const Q = assembleQuery(
@@ -413,87 +444,13 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
                     false
                 );
                 return Q.shader;
-            },
+          },
+
             build: (device: GPUDevice, label: string) => {
-                const Q = assembleQuery(
-                    {
-                        from: this.from as string,
-                        selections: this.selections,
-                        tables,
-                        uniformName: UNI_INSTANCE_NAME,
-                        uniformTypeName: UNI_STRUCT_TYPE_NAME,
-                    },
-                    predicateExpr,
-                    paramDecls,
-                    64,
-                    false
-                );
-                const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-                const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
-                const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-                    const unis = wgh.makeStructuredView(uniDef, buffer);
-                    unis.set(parameters);
-                    return unis.arrayBuffer;
-                };
-                const { runner, validate } = makeRunner({
-                    device,
-                    indexed: false,
-                    label,
-                    pipe,
-                    safeLookups: columnBindings,
-                    serializeParameters,
-                    shader: Q.shader,
-                    wgSize: WG_SIZE,
-                });
-                return {
-                    run: runner,
-                    validate,
-                    serializeParameters,
-                    pipeline: pipe,
-                    parameterTypeDef: uniDef,
-                    // validate:partial(validate,false) // todo fix validate
-                };
+              return buildHelper(device, label, false);
             },
             buildIndexed: (device: GPUDevice, label: string) => {
-                const Q = assembleQuery(
-                    {
-                        from: this.from as string,
-                        selections: this.selections,
-                        tables,
-                        uniformName: UNI_INSTANCE_NAME,
-                        uniformTypeName: 'Params',
-                    },
-                    predicateExpr,
-                    paramDecls,
-                    64,
-                    true
-                );
-                const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-                const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
-                const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-                    const unis = wgh.makeStructuredView(uniDef, buffer);
-                    unis.set(parameters);
-                    return unis.arrayBuffer;
-                };
-                const { runner, validate } = makeRunner({
-                    device,
-                    indexed: true,
-                    label,
-                    pipe,
-                    safeLookups: columnBindings,
-                    serializeParameters,
-                    shader: Q.shader,
-                    wgSize: WG_SIZE,
-                });
-
-                return {
-                    run: runner,
-                    validate,
-                    serializeParameters,
-                    pipeline: pipe,
-                    parameterTypeDef: uniDef,
-                    // validate:partial(validate,true)
-                };
+                return buildHelper(device, label, true);
             },
         };
     }

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -523,9 +523,9 @@ export function given<Ts extends Tables>(tables: Ts) {
                     kind: 'from field',
                     from: from as string,
                     field: k,
-                  type: undefined as unknown as WgslType,
-                  /* oxlint-disabletypescript/no-explicit-any */
-                } as unknown as any
+                    type: undefined as unknown as WgslType,
+                    /* oxlint-disabletypescript/no-explicit-any */
+                } as unknown as any;
             }
             function table<Other extends Exclude<keyof Ts, From>>(t: Other) {
                 return {

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -1,382 +1,486 @@
-import { buildFilterPipeline } from "./build";
-import { assembleQuery } from "./gen";
-import * as wgh from 'webgpu-utils'
-import type { alpha,Tables,SwizzleIndexExpr, ComponentType, IndexExpr, SwizzleExpr, AST, BufferTables, ColumnExpr, OP, PExpr, RunFilterArgs, RunIndexedFilterArgs, Sel, TsType, VOP, WgslType, ScalarType, VLen, VectorType, onlyLetters, FType, Cmp, BTables,} from "./types";
-import * as lo from 'lodash'
+import { buildFilterPipeline } from './build';
+import { assembleQuery } from './gen';
+import * as wgh from 'webgpu-utils';
+import type {
+    alpha,
+    Tables,
+    SwizzleIndexExpr,
+    ComponentType,
+    IndexExpr,
+    SwizzleExpr,
+    AST,
+    BufferTables,
+    ColumnExpr,
+    OP,
+    PExpr,
+    RunFilterArgs,
+    RunIndexedFilterArgs,
+    Sel,
+    TsType,
+    VOP,
+    WgslType,
+    ScalarType,
+    VLen,
+    VectorType,
+    onlyLetters,
+    FType,
+    Cmp,
+    BTables,
+} from './types';
+import * as lo from 'lodash';
 const { mapValues } = lo;
 
 const entries = <T extends {}>(r: T): ReadonlyArray<[keyof T, T[keyof T]]> => Object.entries(r) as any;
 
-export function given<Ts extends Tables>(
-  tables: Ts,
-) {
-  return {
-    from: <From extends keyof Ts>(from:From)=>{
-      function column<
-        E extends SwizzleExpr<Ts, From, keyof Ts[From]>
-      >(k: E): E extends `${infer Field}.${string}` ? ColumnExpr<string, string, Cmp<FType<Ts[From],Field>>> : E extends `${infer Field}` ? ColumnExpr<string, string, FType<Ts[From],Field>> : never {
-        return {
-          kind: 'from field',
-          from: from as string,
-          field: k,
-          type: undefined as unknown as any
-        } as any;
-      }
-      function table<Other extends Exclude<keyof Ts, From>>(t: Other) {
-        return {
-          at: <E extends SwizzleIndexExpr<Ts, From, keyof Ts[From]>>(
-            indexExpr: E | IndexExpr<string, string, "u32">,
-          ) => {
-            return {
-              dot: <Field extends keyof Ts[Other], OE extends SwizzleExpr<Ts, Other, Field>>(
-                field: OE,
-              ) => {
-                const IE: IndexExpr<
-                  string,
-                  string,
-                  ComponentType<Ts, Other, Field, OE>
-                > = {
-                  kind: "table at field",
-                  table: t as string,
-                  field: field,
-                  atExpr: indexExpr,
-                  type: undefined as unknown as ComponentType<Ts, Other,Field, OE>, // TODO!
+export function given<Ts extends Tables>(tables: Ts) {
+    return {
+        from: <From extends keyof Ts>(from: From) => {
+            function column<E extends SwizzleExpr<Ts, From, keyof Ts[From]>>(
+                k: E
+            ): E extends `${infer Field}.${string}`
+                ? ColumnExpr<string, string, Cmp<FType<Ts[From], Field>>>
+                : E extends `${infer Field}`
+                  ? ColumnExpr<string, string, FType<Ts[From], Field>>
+                  : never {
+                return {
+                    kind: 'from field',
+                    from: from as string,
+                    field: k,
+                    type: undefined as unknown as any,
+                } as any;
+            }
+            function table<Other extends Exclude<keyof Ts, From>>(t: Other) {
+                return {
+                    at: <E extends SwizzleIndexExpr<Ts, From, keyof Ts[From]>>(
+                        indexExpr: E | IndexExpr<string, string, 'u32'>
+                    ) => {
+                        return {
+                            dot: <Field extends keyof Ts[Other], OE extends SwizzleExpr<Ts, Other, Field>>(
+                                field: OE
+                            ) => {
+                                const IE: IndexExpr<string, string, ComponentType<Ts, Other, Field, OE>> = {
+                                    kind: 'table at field',
+                                    table: t as string,
+                                    field: field,
+                                    atExpr: indexExpr,
+                                    type: undefined as unknown as ComponentType<Ts, Other, Field, OE>, // TODO!
+                                };
+                                return IE;
+                            },
+                        };
+                    },
                 };
-                return IE;
-              },
-            };
-          },
-        };
-      }
-      function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(lhs: IndexExpr<string,string,L>|ColumnExpr<string,string,L>, op: L extends ScalarType ? OP : VOP, rhs: onlyLetters<P>) {
-        return {
-          kind: 'predicate',
-          lhs,
-          op,
-          rhs
-        } as const;
-      }
-      class Clause<Params extends Record<string, string | number | number[]>> {
-        predicates: Array<PExpr<`${alpha}${string}`>>;
-        constructor(preds:Array<ReturnType<typeof predicate<VLen, WgslType, `${alpha}${string}`>>>) {
-          this.predicates = preds;
-        }
-        or<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>, op: L extends ScalarType ? OP : VOP, rhs: onlyLetters<P>) {
-          return new Clause<Params & { [k in P]: TsType<L> }>([...this.predicates, predicate(lhs,op,rhs)]);
-        }
-        paramDeclarations() {
-          return this.predicates.reduce((acc, p) => ({ ...acc, [p.rhs]: determineType(p.lhs) }), {} as Record<string,string>)
-        }
-        // finish(params: Params) {
-
-        // }
-      }
-
-      function any<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>, op: L extends ScalarType ? OP : VOP, rhs: onlyLetters<P>) {
-        return new Clause<{ [k in P]: TsType<L> }>([predicate(lhs,op,rhs)]);
-      }
-      class AndGroup<Params extends Record<string, string | number | number[]>>{
-        ands: Clause<Record<string,any>>[];
-        constructor(clauses:Clause<Record<string,any>>[]) {
-          this.ands = clauses;
-        }
-        and<GroupParams extends Record<string, string | number | number[]>>(clause: Clause<GroupParams>) {
-          return new AndGroup<GroupParams&Params>([...this.ands,clause])
-        }
-        paramDeclarations() {
-          return this.ands.reduce((acc, clause) => ({ ...acc, ...clause.paramDeclarations() }), {} as Record<string,string>)
-        }
-        // finish(params: Params) {
-
-        // }
-      }
-      function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
-        return new AndGroup<Params>([clause])
-      }
-      function isVecOp(s: OP | VOP): s is VOP {
-          return s.startsWith('a');
-      }
-      function parseVecOp(op: VOP) {
-          const aggregation = op.substring(0, 3);
-          const sop = op.substring(4).split(')')[0];
-          return [aggregation, sop] as ['any' | 'all', OP];
-      }
-      function compy(ast: AST, indexing: string,uniName:string):string {
-        switch (ast.kind) {
-          case 'from field':
-            {
-              const [column, swizzle] = ast.field.split('.');
-              return swizzle ? `${ast.from}_${column}[${indexing}].${swizzle}` : `${ast.from}_${column}[${indexing}]`
             }
-          case 'table at field':
-            const subExpr = typeof ast.atExpr === 'string' ?
-              `[${compy({kind:'from field',field:ast.atExpr,from:from as string,type:undefined as any},indexing,uniName)}]` :
-              `[${compy(ast.atExpr,indexing,uniName)}]`;
-            const [column, swizzle] = ast.field.split('.');
-            const sel: string = `${ast.table}_${column}${subExpr}`;
-            return swizzle ? `${sel}.${swizzle}` : sel;
-          case 'predicate':
-            const { lhs, op, rhs } = ast;
-            if (isVecOp(op)) {
-              const [agg, sop] = parseVecOp(op);
-              return `${agg}(${compy(lhs,indexing,uniName)} ${sop} ${uniName}.${rhs})`
+            function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
+                lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
+                op: L extends ScalarType ? OP : VOP,
+                rhs: onlyLetters<P>
+            ) {
+                return {
+                    kind: 'predicate',
+                    lhs,
+                    op,
+                    rhs,
+                } as const;
             }
-            return `${compy(lhs,indexing,uniName)} ${op} ${uniName}.${rhs}`
-        }
-      }
-      function compilePredicate<Params extends Record<string, string | number | number[]>>(group: AndGroup<Params> | Clause<Params>, uniName:string) {
-        return group instanceof AndGroup ?
-          group.ands.flatMap(c => `(${c.predicates.flatMap(p=>compy(p,'element',uniName)).join(' || ')})`).join(' && ') :
-          group.predicates.flatMap( p=>compy(p,'element',uniName)).join(' || ');
-      }
-      function componentType(t: WgslType):ScalarType{
-        if (t.startsWith('vec')) {
-          const abbr = t.substring(4);
-          switch (abbr) {
-            case 'u':
-              return 'u32'
-            case 'i':
-              return 'i32'
-            case 'f':
-            return 'f32'
-          }
-        }
-        return t as ScalarType;
-      }
-      function determineType(expr: '$index'|IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>): WgslType {
-        if (expr === '$index') return 'u32'
-        switch (expr.kind) {
-          case 'from field':
-            {
-              const [field, swizzle] = expr.field.split('.');
-              return swizzle ? componentType(tables[expr.from]![field!]!) : tables[expr.from]![field!]!
-            }
-          case 'table at field':
-            {
-              const [field, swizzle] = expr.field.split('.');
-              return swizzle ? componentType(tables[expr.table]![field!]!) : tables[expr.table]![field!]!
-            }
-        }
-
-      }
-      function mapTablesToBindings<Ts extends Tables>(tables: BufferTables<Ts>, lookups: Record<string, Record<string, number>>) {
-        return entries(tables).flatMap(([name, table]) => {
-          return entries(table).map(([field, buffer]) => {
-            // I promise, these are all strings, its ok
-            const b = lookups[name as string]?.[field as string];
-            if (b) {
-              return { resource: buffer, binding: b }
-            }
-            console.log('omit ', name, field, ' its not referenced!')
-            return undefined;
-          })
-        }).filter(x => x !== undefined)
-      }
-      class Selection {
-        selections: ReadonlyArray<Sel>
-        constructor(selections: ReadonlyArray<Sel>) {
-          this.selections = selections
-        }
-        select(selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>) {
-          const s = selection === '$index' ? 'tmp - 1' : compy(selection,'tmp - 1',''); // uni-name not relavant in selection...
-          const type = determineType(selection);
-          return new Selection([...this.selections,{selection:s,type}])
-        }
-        where<Params extends Parameters>(predicates: AndGroup<Params> | Clause<Params>) {
-
-          // constants //
-          const START_BINDING = 3;
-          const UNI_INSTANCE_NAME = 'params'
-          const UNI_STRUCT_TYPE_NAME = 'Params'
-          const WG_SIZE=64
-          const paramTypes = predicates.paramDeclarations();
-          const paramDecls = entries(paramTypes).map(([name,type])=>`${name}:${type}`).join(',\n')
-          // const uniDecl = `struct ${UNI_STRUCT_NAME} {
-          //   ${paramDecls}
-          //   };`
-          const predicateExpr = `(${compilePredicate(predicates,UNI_INSTANCE_NAME)})`;
-          let binding = START_BINDING;
-          let columnBindings: Record<string,Record<string, number>> = {}
-          // associate a binding with every field of every table
-          for (const t of Object.keys(tables)) {
-            columnBindings[t] = {}
-            for (const col of Object.keys(tables[t]!)) {
-              columnBindings[t]![col] = binding;
-              binding += 1;
-            }
-          }
-          const makeRunner = <Indexed extends boolean>(options: { device: GPUDevice, pipe: ReturnType<typeof buildFilterPipeline>, shader: string, safeLookups: Record<string, Record<string, number>>, indexed: Indexed, label: string, wgSize: number, serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer }) => {
-            const {device,pipe,safeLookups,indexed,label,wgSize} = options;
-            const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
-                const { enc, parameters, sets, timestampWrites } = args;
-                // here, we zero out the result counters
-                // TODO - consider not doing this - if we didnt do that:
-                // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
-                // 2. we technically could invoke this whole thing in an open compute pass...? right?
-                args.sets.forEach((s) => {
-                    device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
-                });
-                const bindings = indexed
-                    ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
-                          return device.createBindGroup({
-                              layout: pipe.pipeline.getBindGroupLayout(1),
-                              entries: [
-                                { binding: 0, resource: s.resultCounter },
-                                { binding: 1, resource: s.results },
-                                  { binding: 2, resource: s.elements },
-                                  ...mapTablesToBindings(s.tables, safeLookups),
-                              ],
-                          });
-                      })
-                    : args.sets.map((s, i) => {
-                          return device.createBindGroup({
-                              layout: pipe.pipeline.getBindGroupLayout(1),
-                              entries: [
-                                  { binding: 0, resource: s.resultCounter },
-                                  { binding: 1, resource: s.results },
-                                  ...mapTablesToBindings(s.tables, safeLookups),
-                              ],
-                          });
-                      });
-
-                const bg0 = device.createBindGroup({
-                    layout: pipe.pipeline.getBindGroupLayout(0),
-                    entries: [{ binding: 0, resource: parameters }],
-                });
-
-                const pass = enc.beginComputePass(
-                    timestampWrites
-                        ? {
-                              label,
-                              timestampWrites,
-                          }
-                        : { label }
-                );
-                pass.setPipeline(pipe.pipeline);
-                pass.setBindGroup(0, bg0);
-                for (let i = 0; i < sets.length; i++) {
-                    const s = sets[i]!;
-                    const bg1 = bindings[i]!;
-                    // console.log('running filter-->',s.results.label)
-                    pass.setBindGroup(1, bg1);
-                    const dispatchCount = Math.ceil(s.rowCount / wgSize);
-                    pass.dispatchWorkgroups(dispatchCount);
+            class Clause<Params extends Record<string, string | number | number[]>> {
+                predicates: Array<PExpr<`${alpha}${string}`>>;
+                constructor(preds: Array<ReturnType<typeof predicate<VLen, WgslType, `${alpha}${string}`>>>) {
+                    this.predicates = preds;
                 }
-                pass.end();
-            };
-            return runner;
-        }
+                or<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
+                    lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
+                    op: L extends ScalarType ? OP : VOP,
+                    rhs: onlyLetters<P>
+                ) {
+                    return new Clause<Params & { [k in P]: TsType<L> }>([...this.predicates, predicate(lhs, op, rhs)]);
+                }
+                paramDeclarations() {
+                    return this.predicates.reduce(
+                        (acc, p) => ({ ...acc, [p.rhs]: determineType(p.lhs) }),
+                        {} as Record<string, string>
+                    );
+                }
+                // finish(params: Params) {
 
+                // }
+            }
 
+            function any<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(
+                lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>,
+                op: L extends ScalarType ? OP : VOP,
+                rhs: onlyLetters<P>
+            ) {
+                return new Clause<{ [k in P]: TsType<L> }>([predicate(lhs, op, rhs)]);
+            }
+            class AndGroup<Params extends Record<string, string | number | number[]>> {
+                ands: Clause<Record<string, any>>[];
+                constructor(clauses: Clause<Record<string, any>>[]) {
+                    this.ands = clauses;
+                }
+                and<GroupParams extends Record<string, string | number | number[]>>(clause: Clause<GroupParams>) {
+                    return new AndGroup<GroupParams & Params>([...this.ands, clause]);
+                }
+                paramDeclarations() {
+                    return this.ands.reduce(
+                        (acc, clause) => ({ ...acc, ...clause.paramDeclarations() }),
+                        {} as Record<string, string>
+                    );
+                }
+                // finish(params: Params) {
 
-
-          return {
-            shaderOnly: () => {
-              const Q = assembleQuery({
-                from:from as string,
-                selections: this.selections,
-                tables,
-                uniformName: UNI_INSTANCE_NAME,
-                uniformTypeName:'Params'
-              }, predicateExpr, paramDecls, 64, false);
-              return Q.shader;
-            },
-            build: (device: GPUDevice, label:string) => {
-              const Q = assembleQuery({
-                from:from as string,
-                selections: this.selections,
-                tables,
-                uniformName: UNI_INSTANCE_NAME,
-                uniformTypeName:UNI_STRUCT_TYPE_NAME
-              }, predicateExpr, paramDecls, 64, false);
-              const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-              const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
-              const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-                  const unis = wgh.makeStructuredView(uniDef, buffer);
-                  unis.set(parameters);
-                  return unis.arrayBuffer;
-              };
-                const runner = makeRunner({ device, indexed: false, label, pipe, safeLookups: columnBindings, serializeParameters, shader: Q.shader, wgSize: WG_SIZE })
-                return {
-                    run:runner,
-                    serializeParameters,
-                    pipeline: pipe,
-                    parameterTypeDef: uniDef,
-                    // validate:partial(validate,false) // todo fix validate
-              }
-            },
-            buildIndexed: (device: GPUDevice,label:string) => {
-              const Q = assembleQuery({
-                from:from as string,
-                selections: this.selections,
-                tables,
-                uniformName: UNI_INSTANCE_NAME,
-                uniformTypeName:'Params'
-              }, predicateExpr, paramDecls, 64, true);
-              const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-              const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
-              const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-                  const unis = wgh.makeStructuredView(uniDef, buffer);
-                  unis.set(parameters);
-                  return unis.arrayBuffer;
-              };
-                const runner = makeRunner({ device, indexed: true, label, pipe, safeLookups: columnBindings, serializeParameters, shader: Q.shader, wgSize: WG_SIZE })
-                return {
-                  run:runner,
-                  serializeParameters,
-                  pipeline: pipe,
-                    parameterTypeDef: uniDef,
-                  // validate:partial(validate,true)
+                // }
+            }
+            function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
+                return new AndGroup<Params>([clause]);
+            }
+            function isVecOp(s: OP | VOP): s is VOP {
+                return s.startsWith('a');
+            }
+            function parseVecOp(op: VOP) {
+                const aggregation = op.substring(0, 3);
+                const sop = op.substring(4).split(')')[0];
+                return [aggregation, sop] as ['any' | 'all', OP];
+            }
+            function compy(ast: AST, indexing: string, uniName: string): string {
+                switch (ast.kind) {
+                    case 'from field': {
+                        const [column, swizzle] = ast.field.split('.');
+                        return swizzle
+                            ? `${ast.from}_${column}[${indexing}].${swizzle}`
+                            : `${ast.from}_${column}[${indexing}]`;
+                    }
+                    case 'table at field':
+                        const subExpr =
+                            typeof ast.atExpr === 'string'
+                                ? `[${compy({ kind: 'from field', field: ast.atExpr, from: from as string, type: undefined as any }, indexing, uniName)}]`
+                                : `[${compy(ast.atExpr, indexing, uniName)}]`;
+                        const [column, swizzle] = ast.field.split('.');
+                        const sel: string = `${ast.table}_${column}${subExpr}`;
+                        return swizzle ? `${sel}.${swizzle}` : sel;
+                    case 'predicate':
+                        const { lhs, op, rhs } = ast;
+                        if (isVecOp(op)) {
+                            const [agg, sop] = parseVecOp(op);
+                            return `${agg}(${compy(lhs, indexing, uniName)} ${sop} ${uniName}.${rhs})`;
+                        }
+                        return `${compy(lhs, indexing, uniName)} ${op} ${uniName}.${rhs}`;
                 }
             }
-          }
-        }
-      }
-      function select(selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>) {
-        const s = selection === '$index' ? 'tmp - 1' : compy(selection,'tmp - 1','');
-        const type = determineType(selection);
-        return new Selection([{selection:s,type}])
-      }
+            function compilePredicate<Params extends Record<string, string | number | number[]>>(
+                group: AndGroup<Params> | Clause<Params>,
+                uniName: string
+            ) {
+                return group instanceof AndGroup
+                    ? group.ands
+                          .flatMap((c) => `(${c.predicates.flatMap((p) => compy(p, 'element', uniName)).join(' || ')})`)
+                          .join(' && ')
+                    : group.predicates.flatMap((p) => compy(p, 'element', uniName)).join(' || ');
+            }
+            function componentType(t: WgslType): ScalarType {
+                if (t.startsWith('vec')) {
+                    const abbr = t.substring(4);
+                    switch (abbr) {
+                        case 'u':
+                            return 'u32';
+                        case 'i':
+                            return 'i32';
+                        case 'f':
+                            return 'f32';
+                    }
+                }
+                return t as ScalarType;
+            }
+            function determineType(
+                expr: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
+            ): WgslType {
+                if (expr === '$index') return 'u32';
+                switch (expr.kind) {
+                    case 'from field': {
+                        const [field, swizzle] = expr.field.split('.');
+                        return swizzle ? componentType(tables[expr.from]![field!]!) : tables[expr.from]![field!]!;
+                    }
+                    case 'table at field': {
+                        const [field, swizzle] = expr.field.split('.');
+                        return swizzle ? componentType(tables[expr.table]![field!]!) : tables[expr.table]![field!]!;
+                    }
+                }
+            }
+            function mapTablesToBindings<Ts extends Tables>(
+                tables: BufferTables<Ts>,
+                lookups: Record<string, Record<string, number>>
+            ) {
+                return entries(tables)
+                    .flatMap(([name, table]) => {
+                        return entries(table).map(([field, buffer]) => {
+                            // I promise, these are all strings, its ok
+                            const b = lookups[name as string]?.[field as string];
+                            if (b) {
+                                return { resource: buffer, binding: b };
+                            }
+                            console.log('omit ', name, field, ' its not referenced!');
+                            return undefined;
+                        });
+                    })
+                    .filter((x) => x !== undefined);
+            }
+            class Selection {
+                selections: ReadonlyArray<Sel>;
+                constructor(selections: ReadonlyArray<Sel>) {
+                    this.selections = selections;
+                }
+                select(
+                    selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
+                ) {
+                    const s = selection === '$index' ? 'tmp - 1' : compy(selection, 'tmp - 1', ''); // uni-name not relavant in selection...
+                    const type = determineType(selection);
+                    return new Selection([...this.selections, { selection: s, type }]);
+                }
+                where<Params extends Parameters>(predicates: AndGroup<Params> | Clause<Params>) {
+                    // constants //
+                    const START_BINDING = 3;
+                    const UNI_INSTANCE_NAME = 'params';
+                    const UNI_STRUCT_TYPE_NAME = 'Params';
+                    const WG_SIZE = 64;
+                    const paramTypes = predicates.paramDeclarations();
+                    const paramDecls = entries(paramTypes)
+                        .map(([name, type]) => `${name}:${type}`)
+                        .join(',\n');
+                    // const uniDecl = `struct ${UNI_STRUCT_NAME} {
+                    //   ${paramDecls}
+                    //   };`
+                    const predicateExpr = `(${compilePredicate(predicates, UNI_INSTANCE_NAME)})`;
+                    let binding = START_BINDING;
+                    let columnBindings: Record<string, Record<string, number>> = {};
+                    // associate a binding with every field of every table
+                    for (const t of Object.keys(tables)) {
+                        columnBindings[t] = {};
+                        for (const col of Object.keys(tables[t]!)) {
+                            columnBindings[t]![col] = binding;
+                            binding += 1;
+                        }
+                    }
+                    const makeRunner = <Indexed extends boolean>(options: {
+                        device: GPUDevice;
+                        pipe: ReturnType<typeof buildFilterPipeline>;
+                        shader: string;
+                        safeLookups: Record<string, Record<string, number>>;
+                        indexed: Indexed;
+                        label: string;
+                        wgSize: number;
+                        serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer;
+                    }) => {
+                        const { device, pipe, safeLookups, indexed, label, wgSize } = options;
+                        const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
+                            const { enc, parameters, sets, timestampWrites } = args;
+                            // here, we zero out the result counters
+                            // TODO - consider not doing this - if we didnt do that:
+                            // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
+                            // 2. we technically could invoke this whole thing in an open compute pass...? right?
+                            args.sets.forEach((s) => {
+                                device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
+                            });
+                            const bindings = indexed
+                                ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
+                                      return device.createBindGroup({
+                                          layout: pipe.pipeline.getBindGroupLayout(1),
+                                          entries: [
+                                              { binding: 0, resource: s.resultCounter },
+                                              { binding: 1, resource: s.results },
+                                              { binding: 2, resource: s.elements },
+                                              ...mapTablesToBindings(s.tables, safeLookups),
+                                          ],
+                                      });
+                                  })
+                                : args.sets.map((s, i) => {
+                                      return device.createBindGroup({
+                                          layout: pipe.pipeline.getBindGroupLayout(1),
+                                          entries: [
+                                              { binding: 0, resource: s.resultCounter },
+                                              { binding: 1, resource: s.results },
+                                              ...mapTablesToBindings(s.tables, safeLookups),
+                                          ],
+                                      });
+                                  });
 
+                            const bg0 = device.createBindGroup({
+                                layout: pipe.pipeline.getBindGroupLayout(0),
+                                entries: [{ binding: 0, resource: parameters }],
+                            });
 
+                            const pass = enc.beginComputePass(
+                                timestampWrites
+                                    ? {
+                                          label,
+                                          timestampWrites,
+                                      }
+                                    : { label }
+                            );
+                            pass.setPipeline(pipe.pipeline);
+                            pass.setBindGroup(0, bg0);
+                            for (let i = 0; i < sets.length; i++) {
+                                const s = sets[i]!;
+                                const bg1 = bindings[i]!;
+                                // console.log('running filter-->',s.results.label)
+                                pass.setBindGroup(1, bg1);
+                                const dispatchCount = Math.ceil(s.rowCount / wgSize);
+                                pass.dispatchWorkgroups(dispatchCount);
+                            }
+                            pass.end();
+                        };
+                        return runner;
+                    };
 
-      return { column, table,any,all,clause:any, select };
-    }
-  }
+                    return {
+                        shaderOnly: () => {
+                            const Q = assembleQuery(
+                                {
+                                    from: from as string,
+                                    selections: this.selections,
+                                    tables,
+                                    uniformName: UNI_INSTANCE_NAME,
+                                    uniformTypeName: 'Params',
+                                },
+                                predicateExpr,
+                                paramDecls,
+                                64,
+                                false
+                            );
+                            return Q.shader;
+                        },
+                        build: (device: GPUDevice, label: string) => {
+                            const Q = assembleQuery(
+                                {
+                                    from: from as string,
+                                    selections: this.selections,
+                                    tables,
+                                    uniformName: UNI_INSTANCE_NAME,
+                                    uniformTypeName: UNI_STRUCT_TYPE_NAME,
+                                },
+                                predicateExpr,
+                                paramDecls,
+                                64,
+                                false
+                            );
+                            const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+                            const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+                            const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+                                const unis = wgh.makeStructuredView(uniDef, buffer);
+                                unis.set(parameters);
+                                return unis.arrayBuffer;
+                            };
+                            const runner = makeRunner({
+                                device,
+                                indexed: false,
+                                label,
+                                pipe,
+                                safeLookups: columnBindings,
+                                serializeParameters,
+                                shader: Q.shader,
+                                wgSize: WG_SIZE,
+                            });
+                            return {
+                                run: runner,
+                                serializeParameters,
+                                pipeline: pipe,
+                                parameterTypeDef: uniDef,
+                                // validate:partial(validate,false) // todo fix validate
+                            };
+                        },
+                        buildIndexed: (device: GPUDevice, label: string) => {
+                            const Q = assembleQuery(
+                                {
+                                    from: from as string,
+                                    selections: this.selections,
+                                    tables,
+                                    uniformName: UNI_INSTANCE_NAME,
+                                    uniformTypeName: 'Params',
+                                },
+                                predicateExpr,
+                                paramDecls,
+                                64,
+                                true
+                            );
+                            const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+                            const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+                            const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+                                const unis = wgh.makeStructuredView(uniDef, buffer);
+                                unis.set(parameters);
+                                return unis.arrayBuffer;
+                            };
+                            const runner = makeRunner({
+                                device,
+                                indexed: true,
+                                label,
+                                pipe,
+                                safeLookups: columnBindings,
+                                serializeParameters,
+                                shader: Q.shader,
+                                wgSize: WG_SIZE,
+                            });
+                            return {
+                                run: runner,
+                                serializeParameters,
+                                pipeline: pipe,
+                                parameterTypeDef: uniDef,
+                                // validate:partial(validate,true)
+                            };
+                        },
+                    };
+                }
+            }
+            function select(
+                selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
+            ) {
+                const s = selection === '$index' ? 'tmp - 1' : compy(selection, 'tmp - 1', '');
+                const type = determineType(selection);
+                return new Selection([{ selection: s, type }]);
+            }
 
+            return { column, table, any, all, clause: any, select };
+        },
+    };
 }
-type Parameters = Record<string, string | number | number[]>
-
+type Parameters = Record<string, string | number | number[]>;
 
 // validation at runtime?
 function validate<Ts extends Tables, Params extends Parameters, Indexed extends boolean>(
-  indexed:Indexed,
-    dev:GPUDevice,
+    indexed: Indexed,
+    dev: GPUDevice,
     filter: {
-    serializeParameters: (params: Params) => ArrayBuffer,
-    run: (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>)=>void
-}, tables: BTables<Ts, { buffer: ArrayBuffer }> ,params:Params, expected:{buffer:ArrayBuffer},elements:Uint32Array|number){
-
-    const R = GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
-    const M = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+        serializeParameters: (params: Params) => ArrayBuffer;
+        run: (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => void;
+    },
+    tables: BTables<Ts, { buffer: ArrayBuffer }>,
+    params: Params,
+    expected: { buffer: ArrayBuffer },
+    elements: Uint32Array | number
+) {
+    const R = GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC;
+    const M = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ;
     const enc = dev.createCommandEncoder();
-    const pBytes = filter.serializeParameters(params)
-    const paramB = dev.createBuffer({ size: pBytes.byteLength, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM, label: 'validate params' })
-    dev.queue.writeBuffer(paramB, 0, pBytes)
-  const inputs: GPUBuffer[] = []
-    Object.entries
-    const tableBuffers = mapValues(tables, (table) => mapValues(table, (column:{buffer:ArrayBuffer}) => {
-        const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
-        dev.queue.writeBuffer(buf, 0, column.buffer);
-        inputs.push(buf);
-        return buf;
-    }))
-    const rowCount:number = indexed ? (elements as Uint32Array).length : (elements as number);
+    const pBytes = filter.serializeParameters(params);
+    const paramB = dev.createBuffer({
+        size: pBytes.byteLength,
+        usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM,
+        label: 'validate params',
+    });
+    dev.queue.writeBuffer(paramB, 0, pBytes);
+    const inputs: GPUBuffer[] = [];
+    Object.entries;
+    const tableBuffers = mapValues(tables, (table) =>
+        mapValues(table, (column: { buffer: ArrayBuffer }) => {
+            const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
+            dev.queue.writeBuffer(buf, 0, column.buffer);
+            inputs.push(buf);
+            return buf;
+        })
+    );
+    const rowCount: number = indexed ? (elements as Uint32Array).length : (elements as number);
     let elemBuffer: GPUBuffer | undefined;
     if (indexed && elements instanceof Uint32Array) {
-
-      elemBuffer = dev.createBuffer({ size: elements.buffer.byteLength, usage: R });
-      dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
+        elemBuffer = dev.createBuffer({ size: elements.buffer.byteLength, usage: R });
+        dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
     }
     const resultsCounter = dev.createBuffer({ size: 16, usage: R });
     const resolveCount = dev.createBuffer({ size: 16, usage: M });
@@ -385,41 +489,45 @@ function validate<Ts extends Tables, Params extends Parameters, Indexed extends 
     // @ts-expect-error
     filter.run({
         enc,
-        parameters:paramB,
-        sets: [{
-            elements: elemBuffer,
-            resultCounter: resultsCounter,
-            results,
-            rowCount,
-            tables: tableBuffers,
-        }],
+        parameters: paramB,
+        sets: [
+            {
+                elements: elemBuffer,
+                resultCounter: resultsCounter,
+                results,
+                rowCount,
+                tables: tableBuffers,
+            },
+        ],
     });
     enc.copyBufferToBuffer(results, resolve);
     enc.copyBufferToBuffer(resultsCounter, resolveCount);
-    dev.queue.submit([enc.finish()])
+    dev.queue.submit([enc.finish()]);
     // ok now get the results and compare them!
-    Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)]).then(() => {
-        const count = new Uint32Array(resolveCount.getMappedRange());
-        const recvd = resolve.getMappedRange();
-        // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
-        // if(count[0]!==expected)
-        const dv = new DataView(recvd);
-        const ex = new DataView(expected.buffer);
-        let failBytes = 0;
-        for (let i = 0; i < expected.buffer.byteLength; i++) {
-            if (dv.getUint8(i) !== ex.getUint8(i)) {
-                console.error('filter validation failed at byte: ', i)
-                failBytes += 1;
-              }
+    Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)])
+        .then(() => {
+            const count = new Uint32Array(resolveCount.getMappedRange());
+            const recvd = resolve.getMappedRange();
+            // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
+            // if(count[0]!==expected)
+            const dv = new DataView(recvd);
+            const ex = new DataView(expected.buffer);
+            let failBytes = 0;
+            for (let i = 0; i < expected.buffer.byteLength; i++) {
+                if (dv.getUint8(i) !== ex.getUint8(i)) {
+                    console.error('filter validation failed at byte: ', i);
+                    failBytes += 1;
+                }
             }
-        if (failBytes === 0) {
-          console.log('validation success')
-        }
-    }).finally(() => {
-        // destroy all things
-        [resolve, resolveCount, paramB, resultsCounter, results,...inputs].forEach(b => b.destroy())
-        if (elemBuffer) {
-            elemBuffer.destroy();
-        }
-    })
+            if (failBytes === 0) {
+                console.log('validation success');
+            }
+        })
+        .finally(() => {
+            // destroy all things
+            [resolve, resolveCount, paramB, resultsCounter, results, ...inputs].forEach((b) => b.destroy());
+            if (elemBuffer) {
+                elemBuffer.destroy();
+            }
+        });
 }

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -23,9 +23,9 @@ import type {
     VLen,
     VectorType,
     onlyLetters,
-    FType,
-    Cmp,
     ArrayBufferTables,
+    vKeys,
+    ITable,
 } from './types';
 import * as lo from 'lodash';
 import { logger } from '~/src/logger';
@@ -144,6 +144,10 @@ function componentType(t: WgslType): ScalarType {
         }
     }
     return t as ScalarType;
+}
+function inferType(table:ITable,e: string) {
+  const [field, swizzle] = e.split('.');
+  return swizzle ? componentType(table![field!]!) : table![field!]!;
 }
 function determineType(
     tables: Tables,
@@ -467,38 +471,42 @@ export function given<Ts extends Tables>(tables: Ts) {
     function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
         return new AndGroup<Params>([clause]);
     }
+    // these are fun...  they do belong in types.ts, but moving them there means they no longer directly deal with Ts
+    // I think that discconnect pushes TS over the edge and they end up not working - everything turns to unknown
+    type UnionToIntersection<U> =
+      (U extends any ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never
+    type ExpandTableColumn<T extends keyof Ts,F extends keyof Ts[T]> = F extends string ? vKeys<Ts[T], F> & T : never
+    type ExpandTableVectors<T extends keyof Ts> = keyof Ts[T] extends string ? UnionToIntersection<ExpandTableColumn<T, keyof Ts[T]>>:never
     return {
         from: <From extends keyof Ts>(from: From) => {
-            function column<E extends SwizzleExpr<Ts, From, keyof Ts[From]>>(
+            function column<E extends keyof ExpandTableVectors<From>>(
                 k: E
-            ): E extends `${infer Field}.${string}`
-                ? ColumnExpr<string, string, Cmp<FType<Ts[From], Field>>>
-                : E extends `${infer Field}`
-                  ? ColumnExpr<string, string, FType<Ts[From], Field>>
-                  : never {
+            ):ColumnExpr<string,string,ExpandTableVectors<From>[E]>{
                 return {
                     kind: 'from field',
                     from: from as string,
-                    field: k,
-                    type: undefined as unknown as WgslType,
-                    /* oxlint-disabletypescript/no-explicit-any */
-                } as unknown as any;
+                    field: k as string,
+                    type: inferType(tables[from],k as string) as ExpandTableVectors<From>[E]
+                }
             }
             function table<Other extends Exclude<keyof Ts, From>>(t: Other) {
+
                 return {
                     at: <E extends SwizzleIndexExpr<Ts, From, keyof Ts[From]>>(
                         indexExpr: E | IndexExpr<string, string, 'u32'>
                     ) => {
+
+
                         return {
-                            dot: <Field extends keyof Ts[Other], OE extends SwizzleExpr<Ts, Other, Field>>(
+                          dot: <OE extends keyof ExpandTableVectors<Other>>(
                                 field: OE
                             ) => {
-                                const IE: IndexExpr<string, string, ComponentType<Ts, Other, Field, OE>> = {
+                              const IE: IndexExpr<string, string,ExpandTableVectors<Other>[OE]> = {
                                     kind: 'table at field',
                                     table: t as string,
-                                    field: field,
+                                    field: field as string,
                                     atExpr: indexExpr,
-                                    type: undefined as unknown as ComponentType<Ts, Other, Field, OE>, // TODO!
+                                    type: inferType(tables[t],field as string) as ExpandTableVectors<Other>[OE]
                                 };
                                 return IE;
                             },
@@ -521,3 +529,14 @@ export function given<Ts extends Tables>(tables: Ts) {
     };
 }
 type Parameters = Record<string, string | number | number[]>;
+
+// this function is not exported or called - its only purpose is to explode if something in the above file
+// changes enough to mess up the types - we want restrictive types here, its the whole point
+function typescriptCanary() {
+  type hey = { cells: { A: 'f32', B: 'vec2f' }, edges: { E: 'vec2u', str: 'f32' } }
+  const e = given({ cells: { A: 'f32', B: 'vec2f' }, edges: { E: 'vec2u', str: 'f32' } }).from('edges')
+  // @ts-expect-error
+  e.select('$index').where(e.clause(e.table('cells').at('E.x').dot('B'), '==', 'mom'))
+  // @ts-expect-error
+  e.select('$index').where(e.clause(e.column('E.x'), 'all(==)', 'mom'))
+}

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -1,387 +1,421 @@
-import entries from 'lodash/entries';
-import { buildFilterPipeline } from './build';
-import { genQuery, indexExprType, looksLikeIndexExpr } from './gen';
-import type {
-    Tables,
-    ITable,
-    PredLst,
-    FilterShaderQueryContext,
-    VarName,
-    FilteredTable,
-    RunFilterArgs,
-    PredExpr,
-    Given,
-    GivenTable,
-    SelectedTable,
-    BufferTables,
-    SimplePredExpr,
-    OP,
-    VOP,
-    IndexedReference,
-    RunIndexedFilterArgs,
-    PredicateExpr,
-    TsType,
-    WgslType,
-    Sel,
-} from './types';
-import * as wgh from 'webgpu-utils';
+import { buildFilterPipeline } from "./build";
+import { assembleQuery } from "./gen";
+import * as wgh from 'webgpu-utils'
+import type { alpha,Tables,SwizzleIndexExpr, ComponentType, IndexExpr, SwizzleExpr, AST, BufferTables, ColumnExpr, OP, PExpr, RunFilterArgs, RunIndexedFilterArgs, Sel, TsType, VOP, WgslType, ScalarType, VLen, VectorType, onlyLetters, FType, Cmp, BTables,} from "./types";
+import entries from "lodash/entries";
+import mapValues from "lodash/mapValues";
 
-export class FilterTable<Ts extends Tables, T extends ITable, Params extends Record<string, number | number[]>> {
-    private predicates: PredLst;
-    private ctx: FilterShaderQueryContext<Ts>;
-    constructor(ctx: FilterShaderQueryContext<Ts>, preds?: PredLst) {
-        this.predicates = preds ?? [];
-        this.ctx = ctx;
-    }
-    and<Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ): FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    > {
-        return new FilterTable<
-            Ts,
-            T,
-            typeof pred extends PredicateExpr<T, Ti, Param>
-                ? Params & { [k in Param]: TsType<T[Ti]> }
-                : Params & { [k in Param]: TsType<Ts[O][F]> }
-        >(this.ctx, [...this.predicates, { OP: 'and', pred }]);
-    }
-    or<Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ): FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    > {
-        return new FilterTable<
-            Ts,
-            T,
-            typeof pred extends PredicateExpr<T, Ti, Param>
-                ? Params & { [k in Param]: TsType<T[Ti]> }
-                : Params & { [k in Param]: TsType<Ts[O][F]> }
-        >(this.ctx, [...this.predicates, { OP: 'or', pred }]);
-    }
-    andOpen<Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ): FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    > {
-        return new FilterTable<
-            Ts,
-            T,
-            typeof pred extends PredicateExpr<T, Ti, Param>
-                ? Params & { [k in Param]: TsType<T[Ti]> }
-                : Params & { [k in Param]: TsType<Ts[O][F]> }
-        >(this.ctx, [...this.predicates, { OP: 'and (', pred }]);
-    }
-    orOpen<Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ): FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    > {
-        return new FilterTable<
-            Ts,
-            T,
-            typeof pred extends PredicateExpr<T, Ti, Param>
-                ? Params & { [k in Param]: TsType<T[Ti]> }
-                : Params & { [k in Param]: TsType<Ts[O][F]> }
-        >(this.ctx, [...this.predicates, { OP: 'or (', pred }]);
-    }
-    close() {
-        return new FilterTable<Ts, T, Params>(this.ctx, [...this.predicates, { OP: ')' }]);
-    }
-
-    // build vs. buildIndexed are nearly identical - this function builds either
-    // and does a little TS trickery to help us not repeat the body of the builder
-    private buildHelper<Indexed extends boolean>(
-        device: GPUDevice,
-        label: string,
-        indexed: Indexed
-    ): {
-        shader: string;
-        serializeParameters: (parameters: Params, buffer?: ArrayBuffer) => ArrayBuffer;
-        pipeline: ReturnType<typeof buildFilterPipeline>;
-        run: (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => void;
-    } {
-        const wgSize = 64;
-        const Q = genQuery(this.ctx, this.predicates, wgSize, indexed);
-        const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
-        const withPreds = this.predicates.filter((p) => 'pred' in p);
-        const safeLookups = omitUnreferencedColumns(
-            [this.ctx.firstPred, ...withPreds.map((p) => p.pred)],
-            this.ctx.tables,
-            this.ctx.from,
-            this.ctx.selections,
-            Q.bindingLookups
-        );
-
-        const uniDef = pipe.defs.structs[this.ctx.uniformTypeName]!;
-        const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
-            const unis = wgh.makeStructuredView(uniDef, buffer);
-            unis.set(parameters);
-            return unis.arrayBuffer;
-        };
-
-        const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
-            const { enc, parameters, sets, timestampWrites } = args;
-            // here, we zero out the result counters
-            // TODO - consider not doing this - if we didnt do that:
-            // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
-            // 2. we technically could invoke this whole thing in an open compute pass...? right?
-            args.sets.forEach((s) => {
-                device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
-            });
-            const bindings = indexed
-                ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
-                      return device.createBindGroup({
-                          layout: pipe.pipeline.getBindGroupLayout(1),
-                          entries: [
-                              { binding: 2, resource: s.elements },
-                              { binding: 1, resource: s.results },
-                              { binding: 0, resource: s.resultCounter },
-                              ...mapTablesToBindings(s.tables, safeLookups),
-                          ],
-                      });
-                  })
-                : args.sets.map((s, i) => {
-                      return device.createBindGroup({
-                          layout: pipe.pipeline.getBindGroupLayout(1),
-                          entries: [
-                              { binding: 1, resource: s.results },
-                              { binding: 0, resource: s.resultCounter },
-                              ...mapTablesToBindings(s.tables, safeLookups),
-                          ],
-                      });
-                  });
-
-            const bg0 = device.createBindGroup({
-                layout: pipe.pipeline.getBindGroupLayout(0),
-                entries: [{ binding: 0, resource: parameters }],
-            });
-
-            const pass = enc.beginComputePass(
-                timestampWrites
-                    ? {
-                          label,
-                          timestampWrites,
-                      }
-                    : { label }
-            );
-            pass.setPipeline(pipe.pipeline);
-            pass.setBindGroup(0, bg0);
-            for (let i = 0; i < sets.length; i++) {
-                const s = sets[i]!;
-                const bg1 = bindings[i]!;
-                pass.setBindGroup(1, bg1);
-                const dispatchCount = Math.ceil(s.rowCount / wgSize);
-                pass.dispatchWorkgroups(dispatchCount);
-            }
-            pass.end();
-        };
+export function given<Ts extends Tables>(
+  tables: Ts,
+) {
+  return {
+    from: <From extends keyof Ts>(from:From)=>{
+      function column<
+        E extends SwizzleExpr<Ts, From, keyof Ts[From]>
+      >(k: E): E extends `${infer Field}.${string}` ? ColumnExpr<string, string, Cmp<FType<Ts[From],Field>>> : E extends `${infer Field}` ? ColumnExpr<string, string, FType<Ts[From],Field>> : never {
         return {
-            pipeline: pipe,
-            serializeParameters,
-            shader: Q.shader,
-            run: runner,
+          kind: 'from field',
+          from: from as string,
+          field: k,
+          type: undefined as unknown as any
+        } as any;
+      }
+      function table<Other extends Exclude<keyof Ts, From>>(t: Other) {
+        return {
+          at: <E extends SwizzleIndexExpr<Ts, From, keyof Ts[From]>>(
+            indexExpr: E | IndexExpr<string, string, "u32">,
+          ) => {
+            return {
+              dot: <Field extends keyof Ts[Other], OE extends SwizzleExpr<Ts, Other, Field>>(
+                field: OE,
+              ) => {
+                const IE: IndexExpr<
+                  string,
+                  string,
+                  ComponentType<Ts, Other, Field, OE>
+                > = {
+                  kind: "table at field",
+                  table: t as string,
+                  field: field,
+                  atExpr: indexExpr,
+                  type: undefined as unknown as ComponentType<Ts, Other,Field, OE>, // TODO!
+                };
+                return IE;
+              },
+            };
+          },
         };
-    }
-    build(device: GPUDevice, label: string): ReturnType<FilteredTable<Ts, T, Params>['build']> {
-        return this.buildHelper<false>(device, label, false);
-    }
-    buildIndexed(device: GPUDevice, label: string): ReturnType<FilteredTable<Ts, T, Params>['buildIndexed']> {
-        return this.buildHelper<true>(device, label, true);
-    }
-}
-// unfortunately - wgh doesnt do this for us like I thought it would
-// instead, we have to dig it out of thepredicates
-function collectReferencedColumns(
-    preds: SimplePredExpr[],
-    tables: Tables,
-    from: string
-): { table: string; column: string }[] {
-    return preds.flatMap((p) => references(p, tables, from));
-}
-function references(pred: SimplePredExpr, tables: Tables, from: string) {
-    const [lhs, _op, _rhs] = pred.split(' ') as [string, OP | VOP, string];
-
-    const index = looksLikeIndexExpr(lhs, tables, from);
-    if (index) {
-        return [
-            { table: index.from, column: index.index_field },
-            { table: index.fTable, column: index.selection },
-        ];
-    } else {
-        return [{ table: from, column: lhs }];
-    }
-}
-function omitUnreferencedColumns(
-    preds: SimplePredExpr[],
-    tables: Tables,
-    from: string,
-    select: readonly Sel[],
-    bindings: Record<string, Record<string, number>>
-) {
-    // for each table, for each column
-    // find its binding in the defs
-    // if we cant - we need to omit it at the point at which we create a bindgroup for it
-
-    let safeLookups: Record<string, Record<string, number>> = {};
-    const referenced = collectReferencedColumns(preds, tables, from);
-    const keep = (table: string, column: string, b: number) => {
-        if (!safeLookups[table]) {
-            safeLookups[table] = {};
+      }
+      function predicate<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(lhs: IndexExpr<string,string,L>|ColumnExpr<string,string,L>, op: L extends ScalarType ? OP : VOP, rhs: onlyLetters<P>) {
+        return {
+          kind: 'predicate',
+          lhs,
+          op,
+          rhs
+        } as const;
+      }
+      class Clause<Params extends Record<string, string | number | number[]>> {
+        predicates: Array<PExpr<`${alpha}${string}`>>;
+        constructor(preds:Array<ReturnType<typeof predicate<VLen, WgslType, `${alpha}${string}`>>>) {
+          this.predicates = preds;
         }
-        safeLookups[table][column] = b;
-    };
-    for (const ref of referenced) {
-        const { table, column } = ref;
-        const b = bindings[table]![column]!;
-        keep(table, column, b);
-    }
-    for (const S of select) {
-        const select = S.selection;
-        if (select !== `$index`) {
-            const projected = looksLikeIndexExpr(select, tables, from);
-            if (projected) {
-                keep(projected.from, projected.index_field, bindings[projected.from]![projected.index_field]!);
-                keep(projected.fTable, projected.selection, bindings[projected.fTable]![projected.selection]!);
-            } else {
-                const b = bindings[from]![select]!;
-                keep(from, select, b);
+        or<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>, op: L extends ScalarType ? OP : VOP, rhs: onlyLetters<P>) {
+          return new Clause<Params & { [k in P]: TsType<L> }>([...this.predicates, predicate(lhs,op,rhs)]);
+        }
+        paramDeclarations() {
+          return this.predicates.reduce((acc, p) => ({ ...acc, [p.rhs]: determineType(p.lhs) }), {} as Record<string,string>)
+        }
+        // finish(params: Params) {
+
+        // }
+      }
+
+      function any<S extends VLen, L extends ScalarType | VectorType<S>, P extends `${alpha}${string}`>(lhs: IndexExpr<string, string, L> | ColumnExpr<string, string, L>, op: L extends ScalarType ? OP : VOP, rhs: onlyLetters<P>) {
+        return new Clause<{ [k in P]: TsType<L> }>([predicate(lhs,op,rhs)]);
+      }
+      class AndGroup<Params extends Record<string, string | number | number[]>>{
+        ands: Clause<Record<string,any>>[];
+        constructor(clauses:Clause<Record<string,any>>[]) {
+          this.ands = clauses;
+        }
+        and<GroupParams extends Record<string, string | number | number[]>>(clause: Clause<GroupParams>) {
+          return new AndGroup<GroupParams&Params>([...this.ands,clause])
+        }
+        paramDeclarations() {
+          return this.ands.reduce((acc, clause) => ({ ...acc, ...clause.paramDeclarations() }), {} as Record<string,string>)
+        }
+        // finish(params: Params) {
+
+        // }
+      }
+      function all<Params extends Record<string, string | number | number[]>>(clause: Clause<Params>) {
+        return new AndGroup<Params>([clause])
+      }
+      function isVecOp(s: OP | VOP): s is VOP {
+          return s.startsWith('a');
+      }
+      function parseVecOp(op: VOP) {
+          const aggregation = op.substring(0, 3);
+          const sop = op.substring(4).split(')')[0];
+          return [aggregation, sop] as ['any' | 'all', OP];
+      }
+      function compy(ast: AST, indexing: string,uniName:string):string {
+        switch (ast.kind) {
+          case 'from field':
+            {
+              const [column, swizzle] = ast.field.split('.');
+              return swizzle ? `${ast.from}_${column}[${indexing}].${swizzle}` : `${ast.from}_${column}[${indexing}]`
+            }
+          case 'table at field':
+            const subExpr = typeof ast.atExpr === 'string' ?
+              `[${compy({kind:'from field',field:ast.atExpr,from:from as string,type:undefined as any},indexing,uniName)}]` :
+              `[${compy(ast.atExpr,indexing,uniName)}]`;
+            const [column, swizzle] = ast.field.split('.');
+            const sel: string = `${ast.table}_${column}${subExpr}`;
+            return swizzle ? `${sel}.${swizzle}` : sel;
+          case 'predicate':
+            const { lhs, op, rhs } = ast;
+            if (isVecOp(op)) {
+              const [agg, sop] = parseVecOp(op);
+              return `${agg}(${compy(lhs,indexing,uniName)} ${sop} ${uniName}.${rhs})`
+            }
+            return `${compy(lhs,indexing,uniName)} ${op} ${uniName}.${rhs}`
+        }
+      }
+      function compilePredicate<Params extends Record<string, string | number | number[]>>(group: AndGroup<Params> | Clause<Params>, uniName:string) {
+        return group instanceof AndGroup ?
+          group.ands.flatMap(c => `(${c.predicates.flatMap(p=>compy(p,'element',uniName)).join(' || ')})`).join(' && ') :
+          group.predicates.flatMap( p=>compy(p,'element',uniName)).join(' || ');
+      }
+      function componentType(t: WgslType):ScalarType{
+        if (t.startsWith('vec')) {
+          const abbr = t.substring(4);
+          switch (abbr) {
+            case 'u':
+              return 'u32'
+            case 'i':
+              return 'i32'
+            case 'f':
+            return 'f32'
+          }
+        }
+        return t as ScalarType;
+      }
+      function determineType(expr: '$index'|IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>): WgslType {
+        if (expr === '$index') return 'u32'
+        switch (expr.kind) {
+          case 'from field':
+            {
+              const [field, swizzle] = expr.field.split('.');
+              return swizzle ? componentType(tables[expr.from]![field!]!) : tables[expr.from]![field!]!
+            }
+          case 'table at field':
+            {
+              const [field, swizzle] = expr.field.split('.');
+              return swizzle ? componentType(tables[expr.table]![field!]!) : tables[expr.table]![field!]!
             }
         }
-    }
 
-    return safeLookups;
-}
-function mapTablesToBindings<Ts extends Tables>(
-    tables: BufferTables<Ts>,
-    lookups: Record<string, Record<string, number>>
-) {
-    return entries(tables)
-        .flatMap(([name, table]) => {
-            return entries(table).map(([field, buffer]) => {
-                const b = lookups[name]?.[field];
-                if (b) {
-                    return { resource: buffer, binding: b };
+      }
+      function mapTablesToBindings<Ts extends Tables>(tables: BufferTables<Ts>, lookups: Record<string, Record<string, number>>) {
+        return entries(tables).flatMap(([name, table]) => {
+          return entries(table).map(([field, buffer]) => {
+            const b = lookups[name]?.[field];
+            if (b) {
+              return { resource: buffer, binding: b }
+            }
+            console.log('omit ', name, field, ' its not referenced!')
+            return undefined;
+          })
+        }).filter(x => x !== undefined)
+      }
+      class Selection {
+        selections: ReadonlyArray<Sel>
+        constructor(selections: ReadonlyArray<Sel>) {
+          this.selections = selections
+        }
+        select(selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>) {
+          const s = selection === '$index' ? 'tmp - 1' : compy(selection,'tmp - 1',''); // uni-name not relavant in selection...
+          const type = determineType(selection);
+          return new Selection([...this.selections,{selection:s,type}])
+        }
+        where<Params extends Parameters>(predicates: AndGroup<Params> | Clause<Params>) {
+
+          // constants //
+          const START_BINDING = 3;
+          const UNI_INSTANCE_NAME = 'params'
+          const UNI_STRUCT_TYPE_NAME = 'Params'
+          const WG_SIZE=64
+          const paramTypes = predicates.paramDeclarations();
+          const paramDecls = entries(paramTypes).map(([name,type])=>`${name}:${type}`).join(',\n')
+          // const uniDecl = `struct ${UNI_STRUCT_NAME} {
+          //   ${paramDecls}
+          //   };`
+          const predicateExpr = `(${compilePredicate(predicates,UNI_INSTANCE_NAME)})`;
+          let binding = START_BINDING;
+          let columnBindings: Record<string,Record<string, number>> = {}
+          // associate a binding with every field of every table
+          for (const t of Object.keys(tables)) {
+            columnBindings[t] = {}
+            for (const col of Object.keys(tables[t]!)) {
+              columnBindings[t]![col] = binding;
+              binding += 1;
+            }
+          }
+          const makeRunner = <Indexed extends boolean>(options: { device: GPUDevice, pipe: ReturnType<typeof buildFilterPipeline>, shader: string, safeLookups: Record<string, Record<string, number>>, indexed: Indexed, label: string, wgSize: number, serializeParameters: (p: Params, buffer?: ArrayBuffer) => ArrayBuffer }) => {
+            const {device,pipe,safeLookups,indexed,label,wgSize} = options;
+            const runner = (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>) => {
+                const { enc, parameters, sets, timestampWrites } = args;
+                // here, we zero out the result counters
+                // TODO - consider not doing this - if we didnt do that:
+                // 1. we could potentially accumulate results onto results that had previously been captured in the results buffer
+                // 2. we technically could invoke this whole thing in an open compute pass...? right?
+                args.sets.forEach((s) => {
+                    device.queue.writeBuffer(s.resultCounter, 0, new Uint32Array([0]));
+                });
+                const bindings = indexed
+                    ? (args as RunIndexedFilterArgs<Ts>).sets.map((s, i) => {
+                          return device.createBindGroup({
+                              layout: pipe.pipeline.getBindGroupLayout(1),
+                              entries: [
+                                { binding: 0, resource: s.resultCounter },
+                                { binding: 1, resource: s.results },
+                                  { binding: 2, resource: s.elements },
+                                  ...mapTablesToBindings(s.tables, safeLookups),
+                              ],
+                          });
+                      })
+                    : args.sets.map((s, i) => {
+                          return device.createBindGroup({
+                              layout: pipe.pipeline.getBindGroupLayout(1),
+                              entries: [
+                                  { binding: 0, resource: s.resultCounter },
+                                  { binding: 1, resource: s.results },
+                                  ...mapTablesToBindings(s.tables, safeLookups),
+                              ],
+                          });
+                      });
+
+                const bg0 = device.createBindGroup({
+                    layout: pipe.pipeline.getBindGroupLayout(0),
+                    entries: [{ binding: 0, resource: parameters }],
+                });
+
+                const pass = enc.beginComputePass(
+                    timestampWrites
+                        ? {
+                              label,
+                              timestampWrites,
+                          }
+                        : { label }
+                );
+                pass.setPipeline(pipe.pipeline);
+                pass.setBindGroup(0, bg0);
+                for (let i = 0; i < sets.length; i++) {
+                    const s = sets[i]!;
+                    const bg1 = bindings[i]!;
+                    // console.log('running filter-->',s.results.label)
+                    pass.setBindGroup(1, bg1);
+                    const dispatchCount = Math.ceil(s.rowCount / wgSize);
+                    pass.dispatchWorkgroups(dispatchCount);
                 }
-                return undefined;
-            });
-        })
-        .filter((x) => x !== undefined);
-}
-
-type SelCtx<Ts extends Tables, Tbl extends keyof Ts> = {
-    tables: Ts;
-    tbl: Tbl;
-    selections: ReadonlyArray<Sel>;
-};
-class Selection<Ts extends Tables, Tbl extends keyof Ts> {
-    constructor(readonly ctx: SelCtx<Ts, Tbl>) {}
-    select<Ti extends keyof Ts[Tbl], O extends keyof Ts, oF extends keyof Ts[O]>(
-        f: Ti | '$index' | IndexedReference<Ts[Tbl], Ti, Ts, O, oF>
-    ) {
-        const { tables, tbl, selections } = this.ctx;
-        const additionalSelection = {
-            selection: f as string,
-            type:
-                f === '$index'
-                    ? 'u32'
-                    : (indexExprType(f as string, tables, tbl as string) ?? (tables[tbl]![f]! as WgslType)),
-        } as const;
-        const yay = [...selections, additionalSelection];
-        return new Selection<Ts, Tbl>({
-            ...this.ctx,
-            selections: yay,
-        });
-    }
-    where<Ti extends keyof Ts[Tbl], O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<Ts[Tbl], Ti, Ts, O, F, Param>
-    ) {
-        const { tbl, tables: ts, selections } = this.ctx;
-
-        return new FilterTable<
-            Ts,
-            Ts[Tbl],
-            typeof pred extends PredicateExpr<Ts[Tbl], Ti, Param>
-                ? { [k in Param]: TsType<Ts[Tbl][Ti]> }
-                : { [k in Param]: TsType<Ts[O][F]> }
-        >({
-            firstPred: pred,
-            from: tbl as string,
-            selections,
-            tables: ts,
-            uniformName: 'unis',
-            uniformTypeName: 'Parameters',
-        });
-    }
-}
-
-export function given<Ts extends Tables>(ts: Ts): Given<Ts> {
-    return {
-        from: <Tbl extends keyof Ts>(tbl: Tbl): GivenTable<Ts[Tbl], Ts> => {
-            type T = Ts[Tbl];
-            return {
-                select: <Ti extends keyof T, O extends keyof Ts, oF extends keyof Ts[O]>(
-                    f0: Ti | '$index' | IndexedReference<T, Ti, Ts, O, oF>
-                ): SelectedTable<T, Ts> => {
-                    const firstSelection = {
-                        selection: f0 as string,
-                        type:
-                            f0 === '$index' ? 'u32' : (indexExprType(f0 as string, ts, tbl as string) ?? ts[tbl]![f0]!),
-                    };
-                    return {
-                        select: <Ti extends keyof T, O extends keyof Ts, oF extends keyof Ts[O]>(
-                            f: Ti | '$index' | IndexedReference<T, Ti, Ts, O, oF>
-                        ): SelectedTable<T, Ts> => {
-                            const second = {
-                                selection: f as string,
-                                type:
-                                    f === '$index'
-                                        ? 'u32'
-                                        : (indexExprType(f as string, ts, tbl as string) ?? ts[tbl]![f]!),
-                            };
-                            return new Selection<Ts, Tbl>({
-                                selections: [firstSelection, second],
-                                tables: ts,
-                                tbl,
-                            });
-                        },
-                        where: <Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-                            pred: PredExpr<T, Ti, Ts, O, F, Param>
-                        ) => {
-                            return new FilterTable<
-                                Ts,
-                                T,
-                                typeof pred extends PredicateExpr<T, Ti, Param>
-                                    ? { [k in Param]: TsType<T[Ti]> }
-                                    : { [k in Param]: TsType<Ts[O][F]> }
-                            >({
-                                firstPred: pred,
-                                from: tbl as string,
-                                selections: [],
-                                tables: ts,
-                                uniformName: 'unis',
-                                uniformTypeName: 'Parameters',
-                            });
-                        },
-                    };
-                },
+                pass.end();
             };
-        },
-    };
+            return runner;
+        }
+
+
+
+
+          return {
+            shaderOnly: () => {
+              const Q = assembleQuery({
+                from:from as string,
+                selections: this.selections,
+                tables,
+                uniformName: UNI_INSTANCE_NAME,
+                uniformTypeName:'Params'
+              }, predicateExpr, paramDecls, 64, false);
+              return Q.shader;
+            },
+            build: (device: GPUDevice, label:string) => {
+              const Q = assembleQuery({
+                from:from as string,
+                selections: this.selections,
+                tables,
+                uniformName: UNI_INSTANCE_NAME,
+                uniformTypeName:UNI_STRUCT_TYPE_NAME
+              }, predicateExpr, paramDecls, 64, false);
+              const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+              const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+              const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+                  const unis = wgh.makeStructuredView(uniDef, buffer);
+                  unis.set(parameters);
+                  return unis.arrayBuffer;
+              };
+                const runner = makeRunner({ device, indexed: false, label, pipe, safeLookups: columnBindings, serializeParameters, shader: Q.shader, wgSize: WG_SIZE })
+                return {
+                    run:runner,
+                    serializeParameters,
+                    pipeline: pipe,
+                    parameterTypeDef: uniDef,
+                    // validate:partial(validate,false) // todo fix validate
+              }
+            },
+            buildIndexed: (device: GPUDevice,label:string) => {
+              const Q = assembleQuery({
+                from:from as string,
+                selections: this.selections,
+                tables,
+                uniformName: UNI_INSTANCE_NAME,
+                uniformTypeName:'Params'
+              }, predicateExpr, paramDecls, 64, true);
+              const pipe = buildFilterPipeline(device, Q.shader, 'main', label);
+              const uniDef = pipe.defs.structs[UNI_STRUCT_TYPE_NAME]!;
+              const serializeParameters = (parameters: Params, buffer?: ArrayBuffer) => {
+                  const unis = wgh.makeStructuredView(uniDef, buffer);
+                  unis.set(parameters);
+                  return unis.arrayBuffer;
+              };
+                const runner = makeRunner({ device, indexed: true, label, pipe, safeLookups: columnBindings, serializeParameters, shader: Q.shader, wgSize: WG_SIZE })
+                return {
+                  run:runner,
+                  serializeParameters,
+                  pipeline: pipe,
+                    parameterTypeDef: uniDef,
+                  // validate:partial(validate,true)
+                }
+            }
+          }
+        }
+      }
+      function select(selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>) {
+        const s = selection === '$index' ? 'tmp - 1' : compy(selection,'tmp - 1','');
+        const type = determineType(selection);
+        return new Selection([{selection:s,type}])
+      }
+
+
+
+      return { column, table,any,all,clause:any, select };
+    }
+  }
+
+}
+type Parameters = Record<string, string | number | number[]>
+
+
+// validation at runtime?
+function validate<Ts extends Tables, Params extends Parameters, Indexed extends boolean>(
+  indexed:Indexed,
+    dev:GPUDevice,
+    filter: {
+    serializeParameters: (params: Params) => ArrayBuffer,
+    run: (args: Indexed extends true ? RunIndexedFilterArgs<Ts> : RunFilterArgs<Ts>)=>void
+}, tables: BTables<Ts, { buffer: ArrayBuffer }> ,params:Params, expected:{buffer:ArrayBuffer},elements:Uint32Array|number){
+
+    const R = GPUBufferUsage.COPY_DST | GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
+    const M = GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ
+    const enc = dev.createCommandEncoder();
+    const pBytes = filter.serializeParameters(params)
+    const paramB = dev.createBuffer({ size: pBytes.byteLength, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.UNIFORM, label: 'validate params' })
+    dev.queue.writeBuffer(paramB, 0, pBytes)
+    const inputs: GPUBuffer[]=[]
+    const tableBuffers = mapValues(tables, (table) => mapValues(table, (column:{buffer:ArrayBuffer}) => {
+        const buf = dev.createBuffer({ size: column.buffer.byteLength, usage: R });
+        dev.queue.writeBuffer(buf, 0, column.buffer);
+        inputs.push(buf);
+        return buf;
+    }))
+    const rowCount:number = indexed ? (elements as Uint32Array).length : (elements as number);
+    let elemBuffer: GPUBuffer | undefined;
+    if (indexed && elements instanceof Uint32Array) {
+
+      elemBuffer = dev.createBuffer({ size: elements.buffer.byteLength, usage: R });
+      dev.queue.writeBuffer(elemBuffer, 0, elements.buffer);
+    }
+    const resultsCounter = dev.createBuffer({ size: 16, usage: R });
+    const resolveCount = dev.createBuffer({ size: 16, usage: M });
+    const results = dev.createBuffer({ size: rowCount * 32, usage: R });
+    const resolve = dev.createBuffer({ size: rowCount * 32, usage: M });
+    // @ts-expect-error
+    filter.run({
+        enc,
+        parameters:paramB,
+        sets: [{
+            elements: elemBuffer,
+            resultCounter: resultsCounter,
+            results,
+            rowCount,
+            tables: tableBuffers,
+        }],
+    });
+    enc.copyBufferToBuffer(results, resolve);
+    enc.copyBufferToBuffer(resultsCounter, resolveCount);
+    dev.queue.submit([enc.finish()])
+    // ok now get the results and compare them!
+    Promise.all([resolve.mapAsync(GPUMapMode.READ), resolveCount.mapAsync(GPUMapMode.READ)]).then(() => {
+        const count = new Uint32Array(resolveCount.getMappedRange());
+        const recvd = resolve.getMappedRange();
+        // TODO: we dont know how large each result is... so just compare byte-by-byte for the length of the expected result?
+        // if(count[0]!==expected)
+        const dv = new DataView(recvd);
+        const ex = new DataView(expected.buffer);
+        let failBytes = 0;
+        for (let i = 0; i < expected.buffer.byteLength; i++) {
+            if (dv.getUint8(i) !== ex.getUint8(i)) {
+                console.error('filter validation failed at byte: ', i)
+                failBytes += 1;
+              }
+            }
+        if (failBytes === 0) {
+          console.log('validation success')
+        }
+    }).finally(() => {
+        // destroy all things
+        [resolve, resolveCount, paramB, resultsCounter, results,...inputs].forEach(b => b.destroy())
+        if (elemBuffer) {
+            elemBuffer.destroy();
+        }
+    })
 }

--- a/packages/core/src/rendering/webgpu/filter/types.ts
+++ b/packages/core/src/rendering/webgpu/filter/types.ts
@@ -61,17 +61,6 @@ export type vKeys<T extends ITable, F extends keyof ITable> = F extends string
             : T
     : T;
 
-// doesnt seem to work in general
-
-type ExpandTableColumn<T extends ITable, F extends keyof ITable> = vKeys<T, F> & T;
-
-type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
-
-export type ExpandTableVectors<T extends ITable> = keyof T extends string
-    ? UnionToIntersection<ExpandTableColumn<T, keyof T>>
-    : never;
-export type ValidKeys<T extends ITable> = keyof ExpandTableVectors<T>;
-
 export type ArrayBufferTables<Ts extends Tables> = {
     [k in keyof Ts]: {
         [c in keyof Ts[k]]: {

--- a/packages/core/src/rendering/webgpu/filter/types.ts
+++ b/packages/core/src/rendering/webgpu/filter/types.ts
@@ -53,7 +53,7 @@ export type BufferTables<Ts extends Tables> = {
 };
 export type ArrayBufferTables<Ts extends Tables> = {
     [k in keyof Ts]: {
-         [c in keyof Ts[k]]: {
+        [c in keyof Ts[k]]: {
             buffer: ArrayBuffer;
         };
     };
@@ -153,7 +153,7 @@ export type RunFilterArgs<Ts extends Tables> = {
     sets: {
         resultCounter: GPUBuffer;
         rowCount: number;
-      tables: BufferTables<Ts>;
+        tables: BufferTables<Ts>;
         results: GPUBuffer;
     }[];
     enc: GPUCommandEncoder;

--- a/packages/core/src/rendering/webgpu/filter/types.ts
+++ b/packages/core/src/rendering/webgpu/filter/types.ts
@@ -51,6 +51,21 @@ export type BufferTables<Ts extends Tables> = {
         [c in keyof Ts[k]]: GPUBuffer;
     };
 };
+export type vKeys<T extends ITable, F extends keyof ITable> = F extends string ? T[F] extends `vec2${Abbr}` ?
+  Record<`${F}.${'x' | 'y'}`, Cmp<T[F]>> : T[F] extends `vec3${Abbr}` ? Record<`${F}.${'x' | 'y' | 'z'}`,  Cmp<T[F]>> :
+  T[F] extends `vec4${Abbr}` ? Record<`${F}.${'x' | 'y' | 'z' | 'w'}`,  Cmp<T[F]>> : T : T;
+
+
+  // doesnt seem to work in general
+
+type ExpandTableColumn<T extends ITable, F extends keyof ITable> = vKeys<T, F> & T
+
+type UnionToIntersection<U> =
+  (U extends any ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never
+
+export type ExpandTableVectors<T extends ITable> = keyof T extends string ? UnionToIntersection<ExpandTableColumn<T, keyof T>>:never
+export type ValidKeys<T extends ITable> = keyof ExpandTableVectors<T>
+
 export type ArrayBufferTables<Ts extends Tables> = {
     [k in keyof Ts]: {
         [c in keyof Ts[k]]: {
@@ -58,11 +73,9 @@ export type ArrayBufferTables<Ts extends Tables> = {
         };
     };
 };
-// export type BufferTables<Ts extends Tables> = BTables<Ts, GPUBuffer>;
 export type Elem<T> = T extends ReadonlyArray<infer E> ? E : never;
 export const OPS = ['==', '>', '>=', '<', '<=', '!='] as const;
 export type OP = Elem<typeof OPS>;
-// export const VOPS = ['==' , '!=' , 'any <' , 'any >' , 'all <' , 'all <']
 export type VOP = `${'any' | 'all'}(${OP})`;
 
 export type FType<T extends ITable, K extends keyof T> = T[K];
@@ -116,10 +129,10 @@ export type ComponentType<
     OE extends SwizzleExpr<Ts, Other, Field>,
 > = Field extends string ? (OE extends SwizzledField<Field> ? FType<Ts[Other], Field> : FType<Ts[Other], OE>) : never;
 // not sure why - but componentType goes super banans for simpler, non-index-style expressions... use Cmp instead
-export type Cmp<V extends WgslType> = V extends `vec${infer S}${infer A}` ? `${A}32` : never;
+export type Cmp<V extends WgslType> = V extends `vec${infer S}${infer A extends Abbr}` ? `${A}32` : never;
 // }
 // any expr that resolves to a u32 type?
-export type IndexExpr<Table extends string, Field extends string, T extends ScalarType | VectorType<VLen>> = {
+export type IndexExpr<Table extends string, Field extends string, T> = {
     kind: 'table at field';
     table: Table;
     atExpr: IndexExpr<string, string, 'u32'> | string;
@@ -129,7 +142,7 @@ export type IndexExpr<Table extends string, Field extends string, T extends Scal
 export type ColumnExpr<
     From extends string,
     Field extends string | '$index',
-    T extends ScalarType | VectorType<VLen>,
+    T
 > = {
     kind: 'from field';
     from: From;

--- a/packages/core/src/rendering/webgpu/filter/types.ts
+++ b/packages/core/src/rendering/webgpu/filter/types.ts
@@ -46,10 +46,19 @@ export type BTable<T extends ITable, B> = {
 };
 
 export type Tables = { [table: string]: ITable };
-export type BTables<Ts extends Tables, B> = {
-    [tbl in keyof Ts]: BTable<Ts[tbl], B>;
+export type BufferTables<Ts extends Tables> = {
+    [k in keyof Ts]: {
+        [c in keyof Ts[k]]: GPUBuffer;
+    };
 };
-export type BufferTables<Ts extends Tables> = BTables<Ts, GPUBuffer>;
+export type ArrayBufferTables<Ts extends Tables> = {
+    [k in keyof Ts]: {
+         [c in keyof Ts[k]]: {
+            buffer: ArrayBuffer;
+        };
+    };
+};
+// export type BufferTables<Ts extends Tables> = BTables<Ts, GPUBuffer>;
 export type Elem<T> = T extends ReadonlyArray<infer E> ? E : never;
 export const OPS = ['==', '>', '>=', '<', '<=', '!='] as const;
 export type OP = Elem<typeof OPS>;
@@ -144,7 +153,7 @@ export type RunFilterArgs<Ts extends Tables> = {
     sets: {
         resultCounter: GPUBuffer;
         rowCount: number;
-        tables: BTables<Ts, GPUBuffer>;
+      tables: BufferTables<Ts>;
         results: GPUBuffer;
     }[];
     enc: GPUCommandEncoder;
@@ -157,7 +166,7 @@ export type RunIndexedFilterArgs<Ts extends Tables> = {
         resultCounter: GPUBuffer;
         rowCount: number;
         elements: GPUBuffer;
-        tables: BTables<Ts, GPUBuffer>;
+        tables: BufferTables<Ts>;
         results: GPUBuffer;
     }[];
     enc: GPUCommandEncoder;

--- a/packages/core/src/rendering/webgpu/filter/types.ts
+++ b/packages/core/src/rendering/webgpu/filter/types.ts
@@ -1,178 +1,165 @@
-export type ScalarType = "f32" | "u32" | "i32";
-export type Abbr = "f" | "u" | "i";
+export type ScalarType = 'f32' | 'u32' | 'i32';
+export type Abbr = 'f' | 'u' | 'i';
 export type VLen = 2 | 3 | 4;
 export type VectorType<S extends VLen> = `vec${S}${Abbr}`;
-export type WgslType =
-  ScalarType | VectorType<2> | VectorType<3> | VectorType<4>;
+export type WgslType = ScalarType | VectorType<2> | VectorType<3> | VectorType<4>;
 export type alpha =
-  | "a"
-  | "b"
-  | "c"
-  | "d"
-  | "e"
-  | "f"
-  | "g"
-  | "h"
-  | "i"
-  | "j"
-  | "k"
-  | "l"
-  | "m"
-  | "n"
-  | "o"
-  | "p"
-  | "q"
-  | "r"
-  | "s"
-  | "t"
-  | "u"
-  | "v"
-  | "w"
-  | "x"
-  | "y"
-  | "z";
+    | 'a'
+    | 'b'
+    | 'c'
+    | 'd'
+    | 'e'
+    | 'f'
+    | 'g'
+    | 'h'
+    | 'i'
+    | 'j'
+    | 'k'
+    | 'l'
+    | 'm'
+    | 'n'
+    | 'o'
+    | 'p'
+    | 'q'
+    | 'r'
+    | 's'
+    | 't'
+    | 'u'
+    | 'v'
+    | 'w'
+    | 'x'
+    | 'y'
+    | 'z';
 type letter = alpha | Capitalize<alpha>;
-type justLetters<S extends string> =
-  S extends `${letter}${infer R extends string}`
+type justLetters<S extends string> = S extends `${letter}${infer R extends string}`
     ? justLetters<R> extends true
-      ? true
-      : false
-    : S extends ""
+        ? true
+        : false
+    : S extends ''
       ? true
       : false;
-export type onlyLetters<S extends `${alpha}${string}`> =
-  justLetters<S> extends true ? S : never;
+export type onlyLetters<S extends `${alpha}${string}`> = justLetters<S> extends true ? S : never;
 export type ITable = { [field: string]: WgslType };
 
-
 export type BTable<T extends ITable, B> = {
-  [field in keyof T]: B;
+    [field in keyof T]: B;
 };
 
 export type Tables = { [table: string]: ITable };
-export type BTables<Ts extends Tables,B> = {
-  [tbl in keyof Ts]: BTable<Ts[tbl],B>;
+export type BTables<Ts extends Tables, B> = {
+    [tbl in keyof Ts]: BTable<Ts[tbl], B>;
 };
-export type BufferTables<Ts extends Tables> = BTables<Ts,GPUBuffer>
+export type BufferTables<Ts extends Tables> = BTables<Ts, GPUBuffer>;
 export type Elem<T> = T extends ReadonlyArray<infer E> ? E : never;
-export const OPS = ["==", ">", ">=", "<", "<=", "!="] as const;
+export const OPS = ['==', '>', '>=', '<', '<=', '!='] as const;
 export type OP = Elem<typeof OPS>;
 // export const VOPS = ['==' , '!=' , 'any <' , 'any >' , 'all <' , 'all <']
-export type VOP = `${"any" | "all"}(${OP})`;
+export type VOP = `${'any' | 'all'}(${OP})`;
 
 export type FType<T extends ITable, K extends keyof T> = T[K];
 
 // a ts type for the wgsl type...
 export type TSVec<WT> =
-  WT extends VectorType<infer S>
-    ? S extends 2
-      ? [number, number]
-      : S extends 3
-        ? [number, number, number]
-        : S extends 4
-          ? [number, number, number, number]
-          : never
-    : never;
+    WT extends VectorType<infer S>
+        ? S extends 2
+            ? [number, number]
+            : S extends 3
+              ? [number, number, number]
+              : S extends 4
+                ? [number, number, number, number]
+                : never
+        : never;
 export type TsType<WT> = WT extends ScalarType ? number : TSVec<WT>;
 
-export type Swizzled = `${string}.${"x" | "y" | "z" | "w"}`;
+export type Swizzled = `${string}.${'x' | 'y' | 'z' | 'w'}`;
 
-export type SwizzledField<F extends string> = `${F}.${"x" | "y" | "z" | "w"}`;
+export type SwizzledField<F extends string> = `${F}.${'x' | 'y' | 'z' | 'w'}`;
 
 // so this is getting really annoying - it might be time to try the builder pattern here, too
-export type Swizzle<S extends VLen> = S extends 2
-  ? "x" | "y"
-  : S extends 3
-    ? "x" | "y" | "z"
-    : "x" | "y" | "z" | "w";
+export type Swizzle<S extends VLen> = S extends 2 ? 'x' | 'y' : S extends 3 ? 'x' | 'y' | 'z' : 'x' | 'y' | 'z' | 'w';
 
 export type SwizzleIndexExpr<
-  Ts extends Tables,
-  From extends keyof Ts,
-  Field extends keyof Ts[From],
+    Ts extends Tables,
+    From extends keyof Ts,
+    Field extends keyof Ts[From],
 > = Field extends string
-  ? FType<Ts[From], Field> extends `vec${infer S extends VLen}u`
-    ? `${Field}.${Swizzle<S>}`
-    : FType<Ts[From], Field> extends "u32"
-      ? `${Field}`
-      : never
-  : never;
+    ? FType<Ts[From], Field> extends `vec${infer S extends VLen}u`
+        ? `${Field}.${Swizzle<S>}`
+        : FType<Ts[From], Field> extends 'u32'
+          ? `${Field}`
+          : never
+    : never;
 
-export type SwizzleExpr<
-  Ts extends Tables,
-  From extends keyof Ts,
-  Field extends keyof Ts[From],
-> = Field extends string
-  ? FType<Ts[From], Field> extends VectorType<infer S>
-    ? `${Field}.${Swizzle<S>}` | `${Field}`
-    : FType<Ts[From], Field> extends ScalarType
-      ? `${Field}`
-      : never
-  : never;
+export type SwizzleExpr<Ts extends Tables, From extends keyof Ts, Field extends keyof Ts[From]> = Field extends string
+    ? FType<Ts[From], Field> extends VectorType<infer S>
+        ? `${Field}.${Swizzle<S>}` | `${Field}`
+        : FType<Ts[From], Field> extends ScalarType
+          ? `${Field}`
+          : never
+    : never;
 
 // FType doesnt know about swizzle...
 
 export type ComponentType<
-  Ts extends Tables,
-  Other extends keyof Ts,
-  Field extends keyof Ts[Other],
-  OE extends SwizzleExpr<Ts, Other, Field>,
-> = Field extends string ?
-  OE extends SwizzledField<Field>
-    ? FType<Ts[Other], Field>
-  : FType<Ts[Other], OE>
-    : never
+    Ts extends Tables,
+    Other extends keyof Ts,
+    Field extends keyof Ts[Other],
+    OE extends SwizzleExpr<Ts, Other, Field>,
+> = Field extends string ? (OE extends SwizzledField<Field> ? FType<Ts[Other], Field> : FType<Ts[Other], OE>) : never;
 // not sure why - but componentType goes super banans for simpler, non-index-style expressions... use Cmp instead
 export type Cmp<V extends WgslType> = V extends `vec${infer S}${infer A}` ? `${A}32` : never;
 // }
 // any expr that resolves to a u32 type?
-export type IndexExpr<
-  Table extends string,
-  Field extends string,
-  T extends ScalarType | VectorType<VLen>,
+export type IndexExpr<Table extends string, Field extends string, T extends ScalarType | VectorType<VLen>> = {
+    kind: 'table at field';
+    table: Table;
+    atExpr: IndexExpr<string, string, 'u32'> | string;
+    field: Field;
+    type: T;
+};
+export type ColumnExpr<
+    From extends string,
+    Field extends string | '$index',
+    T extends ScalarType | VectorType<VLen>,
 > = {
-  kind: "table at field";
-  table: Table;
-  atExpr: IndexExpr<string, string, "u32"> | string;
-  field: Field;
-  type: T;
-  };
-export type ColumnExpr<From extends string, Field extends string|'$index',T extends ScalarType | VectorType<VLen>> = {
-  kind: 'from field',
-  from: From;
-  field: Field;
-  type: T
-}
+    kind: 'from field';
+    from: From;
+    field: Field;
+    type: T;
+};
 export type PExpr<P extends `${alpha}${string}`> = {
-  kind: 'predicate',
-  lhs: IndexExpr<string,string,WgslType>|ColumnExpr<string,string,WgslType>,
-  op: OP|VOP,
-  rhs:P
-}
-export type AST = ColumnExpr<string, string, WgslType> | IndexExpr<string, string, WgslType> | PExpr<`${alpha}${string}`>;
+    kind: 'predicate';
+    lhs: IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>;
+    op: OP | VOP;
+    rhs: P;
+};
+export type AST =
+    | ColumnExpr<string, string, WgslType>
+    | IndexExpr<string, string, WgslType>
+    | PExpr<`${alpha}${string}`>;
 
-export type Sel = { selection:string, type: WgslType };
+export type Sel = { selection: string; type: WgslType };
 export type RunFilterArgs<Ts extends Tables> = {
-  parameters: GPUBuffer;
-  sets: {
-    resultCounter: GPUBuffer;
-    rowCount: number;
-    tables: BTables<Ts,GPUBuffer>;
-    results: GPUBuffer;
-  }[];
-  enc: GPUCommandEncoder;
-  timestampWrites?: GPUComputePassTimestampWrites;
+    parameters: GPUBuffer;
+    sets: {
+        resultCounter: GPUBuffer;
+        rowCount: number;
+        tables: BTables<Ts, GPUBuffer>;
+        results: GPUBuffer;
+    }[];
+    enc: GPUCommandEncoder;
+    timestampWrites?: GPUComputePassTimestampWrites;
 };
 
 export type RunIndexedFilterArgs<Ts extends Tables> = {
-  parameters: GPUBuffer;
-  sets: {
-    resultCounter: GPUBuffer;
-    rowCount: number;
-    elements: GPUBuffer;
-    tables: BTables<Ts,GPUBuffer>;
-    results: GPUBuffer;
-  }[];
-  enc: GPUCommandEncoder;
-  timestampWrites?: GPUComputePassTimestampWrites;
+    parameters: GPUBuffer;
+    sets: {
+        resultCounter: GPUBuffer;
+        rowCount: number;
+        elements: GPUBuffer;
+        tables: BTables<Ts, GPUBuffer>;
+        results: GPUBuffer;
+    }[];
+    enc: GPUCommandEncoder;
+    timestampWrites?: GPUComputePassTimestampWrites;
 };

--- a/packages/core/src/rendering/webgpu/filter/types.ts
+++ b/packages/core/src/rendering/webgpu/filter/types.ts
@@ -1,244 +1,178 @@
-import * as wgh from 'webgpu-utils';
-type ScalarType = 'f32' | 'u32' | 'i32';
-type Abbr = 'f' | 'u' | 'i';
-type VLen = 2 | 3 | 4;
-type VectorType<S extends VLen> = `vec${S}${Abbr}`;
-export type WgslType = ScalarType | VectorType<2> | VectorType<3> | VectorType<4>;
-type alpha =
-    | 'a'
-    | 'b'
-    | 'c'
-    | 'd'
-    | 'e'
-    | 'f'
-    | 'g'
-    | 'h'
-    | 'i'
-    | 'j'
-    | 'k'
-    | 'l'
-    | 'm'
-    | 'n'
-    | 'o'
-    | 'p'
-    | 'q'
-    | 'r'
-    | 's'
-    | 't'
-    | 'u'
-    | 'v'
-    | 'w'
-    | 'x'
-    | 'y'
-    | 'z';
+export type ScalarType = "f32" | "u32" | "i32";
+export type Abbr = "f" | "u" | "i";
+export type VLen = 2 | 3 | 4;
+export type VectorType<S extends VLen> = `vec${S}${Abbr}`;
+export type WgslType =
+  ScalarType | VectorType<2> | VectorType<3> | VectorType<4>;
+export type alpha =
+  | "a"
+  | "b"
+  | "c"
+  | "d"
+  | "e"
+  | "f"
+  | "g"
+  | "h"
+  | "i"
+  | "j"
+  | "k"
+  | "l"
+  | "m"
+  | "n"
+  | "o"
+  | "p"
+  | "q"
+  | "r"
+  | "s"
+  | "t"
+  | "u"
+  | "v"
+  | "w"
+  | "x"
+  | "y"
+  | "z";
 type letter = alpha | Capitalize<alpha>;
-
+type justLetters<S extends string> =
+  S extends `${letter}${infer R extends string}`
+    ? justLetters<R> extends true
+      ? true
+      : false
+    : S extends ""
+      ? true
+      : false;
+export type onlyLetters<S extends `${alpha}${string}`> =
+  justLetters<S> extends true ? S : never;
 export type ITable = { [field: string]: WgslType };
-export type BufferTable<T extends ITable> = {
-    [field in keyof T]: GPUBuffer;
+
+
+export type BTable<T extends ITable, B> = {
+  [field in keyof T]: B;
 };
 
 export type Tables = { [table: string]: ITable };
-export type BufferTables<Ts extends Tables> = {
-    [tbl in keyof Ts]: BufferTable<Ts[tbl]>;
+export type BTables<Ts extends Tables,B> = {
+  [tbl in keyof Ts]: BTable<Ts[tbl],B>;
 };
-
+export type BufferTables<Ts extends Tables> = BTables<Ts,GPUBuffer>
 export type Elem<T> = T extends ReadonlyArray<infer E> ? E : never;
-export const OPS = ['==', '>', '>=', '<', '<=', '!='] as const;
+export const OPS = ["==", ">", ">=", "<", "<=", "!="] as const;
 export type OP = Elem<typeof OPS>;
 // export const VOPS = ['==' , '!=' , 'any <' , 'any >' , 'all <' , 'all <']
-export type VOP = `${'any' | 'all'}(${OP})`;
+export type VOP = `${"any" | "all"}(${OP})`;
 
 export type FType<T extends ITable, K extends keyof T> = T[K];
-export type VarName = `${letter}${string}`;
-// type Var<T extends VarName> = `$${T}`
-// I want a type error if the op type is a vOp and either operand is not...
-export type PredicateExpr<T extends ITable, K extends keyof T, Param extends VarName> = K extends string
-    ? FType<T, K> extends VectorType<infer N>
-        ? `${K} ${VOP} ${Param}`
-        : `${K} ${OP} ${Param}`
-    : never;
-export type IndexedReference<
-    T extends ITable,
-    Ti extends keyof T,
-    Ts extends Tables,
-    O extends keyof Ts,
-    F extends keyof Ts[O],
-> = keyof T extends string
-    ? O extends string
-        ? F extends string
-            ? Ti extends string
-                ? FType<T, Ti> extends 'u32'
-                    ? keyof Ts[O] extends string
-                        ? `${O}[${keyof T}].${F}`
-                        : never
-                    : never
-                : never
-            : never
-        : never
-    : never;
-
-export type IndexedPredicateExpr<
-    T extends ITable,
-    Ti extends keyof T,
-    Ts extends Tables,
-    O extends keyof Ts,
-    F extends keyof Ts[O],
-    Param extends VarName,
-> = keyof T extends string
-    ? O extends string
-        ? F extends string
-            ? Ti extends string
-                ? FType<T, Ti> extends 'u32'
-                    ? keyof Ts[O] extends string
-                        ? FType<Ts[O], F> extends VectorType<infer N>
-                            ? `${O}[${keyof T}].${F} ${VOP} ${Param}`
-                            : `${O}[${keyof T}].${F} ${OP} ${Param}`
-                        : never
-                    : never
-                : never
-            : never
-        : never
-    : never;
-
-export type PredExpr<
-    T extends ITable,
-    Ti extends keyof T,
-    Ts extends Tables,
-    O extends keyof Ts,
-    F extends keyof Ts[O],
-    Param extends VarName,
-> = IndexedPredicateExpr<T, Ti, Ts, O, F, Param> | PredicateExpr<T, Ti, Param>;
-
-export type RunFilterArgs<Ts extends Tables> = {
-    parameters: GPUBuffer;
-    sets: {
-        resultCounter: GPUBuffer;
-        rowCount: number;
-        tables: BufferTables<Ts>;
-        results: GPUBuffer;
-    }[];
-    enc: GPUCommandEncoder;
-    timestampWrites?: GPUComputePassTimestampWrites;
-};
-
-export type RunIndexedFilterArgs<Ts extends Tables> = {
-    parameters: GPUBuffer;
-    sets: {
-        resultCounter: GPUBuffer;
-        rowCount: number;
-        elements: GPUBuffer;
-        tables: BufferTables<Ts>;
-        results: GPUBuffer;
-    }[];
-    enc: GPUCommandEncoder;
-    timestampWrites?: GPUComputePassTimestampWrites;
-};
-
-export type FilteredTable<Ts extends Tables, T extends ITable, Params extends Record<string, number | number[]>> = {
-    and: <Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ) => FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    >;
-    or: <Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ) => FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    >;
-    build: (
-        device: GPUDevice,
-        label: string
-    ) => {
-        shader: string;
-        serializeParameters: (parameters: Params, buffer?: ArrayBuffer) => ArrayBuffer;
-        pipeline: { pipeline: GPUComputePipeline; defs: wgh.ShaderDataDefinitions };
-        run: (args: RunFilterArgs<Ts>) => void;
-    };
-    buildIndexed: (
-        device: GPUDevice,
-        label: string
-    ) => {
-        shader: string;
-        serializeParameters: (parameters: Params) => ArrayBuffer;
-        pipeline: { pipeline: GPUComputePipeline; defs: wgh.ShaderDataDefinitions };
-        run: (args: RunIndexedFilterArgs<Ts>) => void;
-    };
-    andOpen: <Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ) => FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    >;
-    orOpen: <Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ) => FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? Params & { [k in Param]: TsType<T[Ti]> }
-            : Params & { [k in Param]: TsType<Ts[O][F]> }
-    >;
-    close: () => FilteredTable<Ts, T, Params>;
-};
-export type SimplePredExpr = `${string} ${OP | VOP} ${string}`;
-export type PredLst = readonly ({ OP: 'and' | 'or' | 'and (' | 'or ('; pred: SimplePredExpr } | { OP: ')' })[];
 
 // a ts type for the wgsl type...
 export type TSVec<WT> =
-    WT extends VectorType<infer S>
-        ? S extends 2
-            ? [number, number]
-            : S extends 3
-              ? [number, number, number]
-              : S extends 4
-                ? [number, number, number, number]
-                : never
-        : never;
+  WT extends VectorType<infer S>
+    ? S extends 2
+      ? [number, number]
+      : S extends 3
+        ? [number, number, number]
+        : S extends 4
+          ? [number, number, number, number]
+          : never
+    : never;
 export type TsType<WT> = WT extends ScalarType ? number : TSVec<WT>;
 
-export type Given<Ts extends Tables> = {
-    from: <Tbl extends keyof Ts>(tbl: Tbl) => GivenTable<Ts[Tbl], Ts>;
-};
-export type GivenTable<T extends ITable, Ts extends Tables> = {
-    select: <Ti extends keyof T, O extends keyof Ts, oF extends keyof Ts[O]>(
-        f: Ti | '$index' | IndexedReference<T, Ti, Ts, O, oF>
-    ) => SelectedTable<T, Ts>;
+export type Swizzled = `${string}.${"x" | "y" | "z" | "w"}`;
+
+export type SwizzledField<F extends string> = `${F}.${"x" | "y" | "z" | "w"}`;
+
+// so this is getting really annoying - it might be time to try the builder pattern here, too
+export type Swizzle<S extends VLen> = S extends 2
+  ? "x" | "y"
+  : S extends 3
+    ? "x" | "y" | "z"
+    : "x" | "y" | "z" | "w";
+
+export type SwizzleIndexExpr<
+  Ts extends Tables,
+  From extends keyof Ts,
+  Field extends keyof Ts[From],
+> = Field extends string
+  ? FType<Ts[From], Field> extends `vec${infer S extends VLen}u`
+    ? `${Field}.${Swizzle<S>}`
+    : FType<Ts[From], Field> extends "u32"
+      ? `${Field}`
+      : never
+  : never;
+
+export type SwizzleExpr<
+  Ts extends Tables,
+  From extends keyof Ts,
+  Field extends keyof Ts[From],
+> = Field extends string
+  ? FType<Ts[From], Field> extends VectorType<infer S>
+    ? `${Field}.${Swizzle<S>}` | `${Field}`
+    : FType<Ts[From], Field> extends ScalarType
+      ? `${Field}`
+      : never
+  : never;
+
+// FType doesnt know about swizzle...
+
+export type ComponentType<
+  Ts extends Tables,
+  Other extends keyof Ts,
+  Field extends keyof Ts[Other],
+  OE extends SwizzleExpr<Ts, Other, Field>,
+> = Field extends string ?
+  OE extends SwizzledField<Field>
+    ? FType<Ts[Other], Field>
+  : FType<Ts[Other], OE>
+    : never
+// not sure why - but componentType goes super banans for simpler, non-index-style expressions... use Cmp instead
+export type Cmp<V extends WgslType> = V extends `vec${infer S}${infer A}` ? `${A}32` : never;
+// }
+// any expr that resolves to a u32 type?
+export type IndexExpr<
+  Table extends string,
+  Field extends string,
+  T extends ScalarType | VectorType<VLen>,
+> = {
+  kind: "table at field";
+  table: Table;
+  atExpr: IndexExpr<string, string, "u32"> | string;
+  field: Field;
+  type: T;
+  };
+export type ColumnExpr<From extends string, Field extends string|'$index',T extends ScalarType | VectorType<VLen>> = {
+  kind: 'from field',
+  from: From;
+  field: Field;
+  type: T
+}
+export type PExpr<P extends `${alpha}${string}`> = {
+  kind: 'predicate',
+  lhs: IndexExpr<string,string,WgslType>|ColumnExpr<string,string,WgslType>,
+  op: OP|VOP,
+  rhs:P
+}
+export type AST = ColumnExpr<string, string, WgslType> | IndexExpr<string, string, WgslType> | PExpr<`${alpha}${string}`>;
+
+export type Sel = { selection:string, type: WgslType };
+export type RunFilterArgs<Ts extends Tables> = {
+  parameters: GPUBuffer;
+  sets: {
+    resultCounter: GPUBuffer;
+    rowCount: number;
+    tables: BTables<Ts,GPUBuffer>;
+    results: GPUBuffer;
+  }[];
+  enc: GPUCommandEncoder;
+  timestampWrites?: GPUComputePassTimestampWrites;
 };
 
-export type Sel = { selection: string; type: WgslType };
-
-export type SelectedTable<T extends ITable, Ts extends Tables> = {
-    select: <Ti extends keyof T, O extends keyof Ts, oF extends keyof Ts[O]>(
-        f: Ti | '$index' | IndexedReference<T, Ti, Ts, O, oF>
-    ) => SelectedTable<T, Ts>;
-    where: <Ti extends keyof T, O extends keyof Ts, F extends keyof Ts[O], Param extends VarName>(
-        pred: PredExpr<T, Ti, Ts, O, F, Param>
-    ) => FilteredTable<
-        Ts,
-        T,
-        typeof pred extends PredicateExpr<T, Ti, Param>
-            ? { [k in Param]: TsType<T[Ti]> }
-            : { [k in Param]: TsType<Ts[O][F]> }
-    >;
-};
-export type FilterShaderQueryContext<Ts extends Tables> = {
-    // hmmm name too silly
-    from: string;
-    tables: Ts;
-    selections: ReadonlyArray<Sel>;
-    firstPred: SimplePredExpr;
-    uniformName: string;
-    uniformTypeName: string;
+export type RunIndexedFilterArgs<Ts extends Tables> = {
+  parameters: GPUBuffer;
+  sets: {
+    resultCounter: GPUBuffer;
+    rowCount: number;
+    elements: GPUBuffer;
+    tables: BTables<Ts,GPUBuffer>;
+    results: GPUBuffer;
+  }[];
+  enc: GPUCommandEncoder;
+  timestampWrites?: GPUComputePassTimestampWrites;
 };

--- a/packages/core/src/rendering/webgpu/filter/types.ts
+++ b/packages/core/src/rendering/webgpu/filter/types.ts
@@ -51,20 +51,26 @@ export type BufferTables<Ts extends Tables> = {
         [c in keyof Ts[k]]: GPUBuffer;
     };
 };
-export type vKeys<T extends ITable, F extends keyof ITable> = F extends string ? T[F] extends `vec2${Abbr}` ?
-  Record<`${F}.${'x' | 'y'}`, Cmp<T[F]>> : T[F] extends `vec3${Abbr}` ? Record<`${F}.${'x' | 'y' | 'z'}`,  Cmp<T[F]>> :
-  T[F] extends `vec4${Abbr}` ? Record<`${F}.${'x' | 'y' | 'z' | 'w'}`,  Cmp<T[F]>> : T : T;
+export type vKeys<T extends ITable, F extends keyof ITable> = F extends string
+    ? T[F] extends `vec2${Abbr}`
+        ? Record<`${F}.${'x' | 'y'}`, Cmp<T[F]>>
+        : T[F] extends `vec3${Abbr}`
+          ? Record<`${F}.${'x' | 'y' | 'z'}`, Cmp<T[F]>>
+          : T[F] extends `vec4${Abbr}`
+            ? Record<`${F}.${'x' | 'y' | 'z' | 'w'}`, Cmp<T[F]>>
+            : T
+    : T;
 
+// doesnt seem to work in general
 
-  // doesnt seem to work in general
+type ExpandTableColumn<T extends ITable, F extends keyof ITable> = vKeys<T, F> & T;
 
-type ExpandTableColumn<T extends ITable, F extends keyof ITable> = vKeys<T, F> & T
+type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
 
-type UnionToIntersection<U> =
-  (U extends any ? (x: U) => void : never) extends ((x: infer I) => void) ? I : never
-
-export type ExpandTableVectors<T extends ITable> = keyof T extends string ? UnionToIntersection<ExpandTableColumn<T, keyof T>>:never
-export type ValidKeys<T extends ITable> = keyof ExpandTableVectors<T>
+export type ExpandTableVectors<T extends ITable> = keyof T extends string
+    ? UnionToIntersection<ExpandTableColumn<T, keyof T>>
+    : never;
+export type ValidKeys<T extends ITable> = keyof ExpandTableVectors<T>;
 
 export type ArrayBufferTables<Ts extends Tables> = {
     [k in keyof Ts]: {
@@ -139,11 +145,7 @@ export type IndexExpr<Table extends string, Field extends string, T> = {
     field: Field;
     type: T;
 };
-export type ColumnExpr<
-    From extends string,
-    Field extends string | '$index',
-    T
-> = {
+export type ColumnExpr<From extends string, Field extends string | '$index', T> = {
     kind: 'from field';
     from: From;
     field: Field;

--- a/site/src/content/docs/webgpu/filtering.mdx
+++ b/site/src/content/docs/webgpu/filtering.mdx
@@ -8,20 +8,21 @@ and a table of connections between those cells (given by indexes start and end),
 the shader is generated using a short, SQL-like builder-style api:
 
 ```ts
-const {table,clause,select,all} = given({
+const { table, clause, select, all } = given({
     cells: { subclass: 'u32', gene_x: 'f32', position: 'vec2f' },
     edges: { start: 'u32', end: 'u32', str: 'f32' },
-})
-.from('edges')
+}).from('edges');
 const filter = select('$index')
-  .select(table('cells').at('start').dot('gene_x'))
-  .select(table('cells').at('start').dot('subclass'))
-  .select(table('cells').at('end').dot('subclass'))
-  .where(all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
-    .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
-    .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
-    .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner')))
-  .build(device);
+    .select(table('cells').at('start').dot('gene_x'))
+    .select(table('cells').at('start').dot('subclass'))
+    .select(table('cells').at('end').dot('subclass'))
+    .where(
+        all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
+            .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
+            .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
+            .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner'))
+    )
+    .build(device);
 ```
 
 As you can see, for an edge to pass the predicate and be included in the results, its starting cell must be within the box from `minCorner` to `maxCorner`, and the `subclass` of the cell at the `start` and `end` of the edge must match `fromClass` and `toClass` respectively. Note also the multiple `select` statements - the requested fields will be packed into the result buffer in the requested order, and displayed in the table after you press the `run!` button.

--- a/site/src/content/docs/webgpu/filtering.mdx
+++ b/site/src/content/docs/webgpu/filtering.mdx
@@ -8,20 +8,20 @@ and a table of connections between those cells (given by indexes start and end),
 the shader is generated using a short, SQL-like builder-style api:
 
 ```ts
-.given({
+const {table,clause,select,all} = given({
     cells: { subclass: 'u32', gene_x: 'f32', position: 'vec2f' },
     edges: { start: 'u32', end: 'u32', str: 'f32' },
 })
 .from('edges')
-.select('$index')
-.select('cells[start].gene_x')
-.select('cells[start].subclass')
-.select('cells[end].subclass')
-.where('cells[end].subclass == toClass')
-.andOpen('cells[start].subclass == fromClass')
-.and('cells[start].position all(>=) minCorner')
-.and('cells[start].position all(<) maxCorner')
-.close()
+const filter = select('$index')
+  .select(table('cells').at('start').dot('gene_x'))
+  .select(table('cells').at('start').dot('subclass'))
+  .select(table('cells').at('end').dot('subclass'))
+  .where(all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
+    .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
+    .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
+    .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner')))
+  .build(device);
 ```
 
 As you can see, for an edge to pass the predicate and be included in the results, its starting cell must be within the box from `minCorner` to `maxCorner`, and the `subclass` of the cell at the `start` and `end` of the edge must match `fromClass` and `toClass` respectively. Note also the multiple `select` statements - the requested fields will be packed into the result buffer in the requested order, and displayed in the table after you press the `run!` button.

--- a/site/src/examples/filter/filter.ts
+++ b/site/src/examples/filter/filter.ts
@@ -38,7 +38,7 @@ function generateFake(dev: GPUDevice, each: (p: number) => number, count: number
 
 const tableLayout = {
     cells: { subclass: 'u32', gene_x: 'f32', position: 'vec2f' },
-    edges: { start: 'u32', end: 'u32', str: 'f32' },
+    edges: { start: 'u32', end: 'u32'},
 } as const;
 type gpuDataset = {
     cells: { [k in keyof (typeof tableLayout)['cells']]: GPUBuffer };
@@ -52,22 +52,32 @@ function generateFakeDataset(device: GPUDevice, edges: number, cells: number): g
     const start = generateFake(device, (r) => Math.floor(r * cells), edges, 'u32');
     const end = generateFake(device, (r) => Math.floor(r * cells), edges, 'u32');
     const str = generateFake(device, (r) => 1.0 + r * 22.0, edges, 'f32');
-    return { cells: { position: positions, subclass, gene_x }, edges: { start, end, str } };
+    return { cells: { position: positions, subclass, gene_x }, edges: { start, end, } };
 }
 
 export function setupDemo(device: GPUDevice, edges: number, cells: number) {
-    const filter = given(tableLayout)
-        .from('edges')
-        .select('$index')
-        .select('cells[start].gene_x')
-        .select('cells[start].subclass')
-        .select('cells[end].subclass')
-        .where('cells[end].subclass == toClass')
-        .andOpen('cells[start].subclass == fromClass')
-        .and('cells[start].position all(>=) minCorner')
-        .and('cells[start].position all(<) maxCorner')
-        .close()
-        .build(device, 'testing');
+  const {all,any,column,table,select,clause } = given(tableLayout)
+    .from('edges');
+
+  const filter = select('$index')
+    .select(table('cells').at('start').dot('gene_x'))
+    .select(table('cells').at('start').dot('subclass'))
+    .select(table('cells').at('end').dot('subclass'))
+    .where(all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
+      .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
+      .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
+      .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner'))).build(device);
+  // .select('$index')
+      //   .select()
+        // .select('cells[start].gene_x')
+        // .select('cells[start].subclass')
+        // .select('cells[end].subclass')
+        // .where('cells[end].subclass == toClass')
+        // .andOpen('cells[start].subclass == fromClass')
+        // .and('cells[start].position all(>=) minCorner')
+        // .and('cells[start].position all(<) maxCorner')
+        // .close()
+        // .build(device, 'testing');
     const outputSizeBytes = 16;
 
     type RowType = readonly [number, number, number, number];
@@ -146,7 +156,7 @@ export function setupDemo(device: GPUDevice, edges: number, cells: number) {
         enc.resolveQuerySet(querySet, 0, querySet.count, resolveBuffer, 0);
         enc.copyBufferToBuffer(resolveBuffer, 0, queryResultBuffer, 0, queryResultBuffer.size);
         enc.copyBufferToBuffer(results, 0, resultReader, 0, edges * outputSizeBytes);
-        enc.copyBufferToBuffer(resultCounter, 0, usedReader, 0, usedReader.size);
+        enc.copyBufferToBuffer(resultCounter, 0, usedReader, 0, resultCounter.size);
         device.queue.submit([enc.finish()]);
         usedReader.mapAsync(GPUMapMode.READ).then(async () => {
             const arr = usedReader.getMappedRange();

--- a/site/src/examples/filter/filter.ts
+++ b/site/src/examples/filter/filter.ts
@@ -1,4 +1,4 @@
-import { given } from '@alleninstitute/vis-core';
+import { given, type ArrayBufferTables } from '@alleninstitute/vis-core';
 
 export async function init() {
     const adapter = await navigator.gpu?.requestAdapter();
@@ -58,28 +58,47 @@ function generateFakeDataset(device: GPUDevice, edges: number, cells: number): g
 export function setupDemo(device: GPUDevice, edges: number, cells: number) {
     const { all, any, column, table, select, clause } = given(tableLayout).from('edges');
 
-    const filter = select('$index')
-        .select(table('cells').at('start').dot('gene_x'))
-        .select(table('cells').at('start').dot('subclass'))
-        .select(table('cells').at('end').dot('subclass'))
+  const filter = select('$index')
+    .select(table('cells').at('start').dot('gene_x'))
+    .select(table('cells').at('start').dot('subclass'))
+    .select(table('cells').at('end').dot('subclass'))
         .where(
             all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
                 .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
                 .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
                 .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner'))
         )
-        .build(device);
-    // .select('$index')
-    //   .select()
-    // .select('cells[start].gene_x')
-    // .select('cells[start].subclass')
-    // .select('cells[end].subclass')
-    // .where('cells[end].subclass == toClass')
-    // .andOpen('cells[start].subclass == fromClass')
-    // .and('cells[start].position all(>=) minCorner')
-    // .and('cells[start].position all(<) maxCorner')
-    // .close()
-    // .build(device, 'testing');
+        .build(device,'example');
+
+  const expectedResults = new DataView(new ArrayBuffer(4 * 4 * 2)) // index,gene,sub,sub, 4 bytes each, 2 expected matches
+  expectedResults.setUint32(0, 1,true) // the first edge
+  expectedResults.setFloat32(4, 0.2,true)
+  expectedResults.setUint32(8, 1,true)
+  expectedResults.setUint32(12, 2,true)
+
+  expectedResults.setUint32(16, 4,true) // the second match, the 5th edge in the list
+  expectedResults.setFloat32(20, 0.2,true)
+  expectedResults.setUint32(24, 1,true)
+  expectedResults.setUint32(28, 2,true)
+  // for fun, validate at runtime?
+  filter.validate(device, filter.serializeParameters, {
+    cells: {
+      position: new Float32Array([
+        0.5, 0.5,
+        0.25, 0.25,
+        0.5, 0.5,
+        0.5, 0.5,
+        2,2, // excluded by the min/max Corner check
+      ]),
+      subclass:new Uint32Array([0,1,2,2,1]),
+      gene_x:new Float32Array([0.1,0.2,0.3,0.4,0.5]),
+    },
+    edges: {
+      start: new Uint32Array([1,1,4,0,1]),
+      end:   new Uint32Array([0,2,3,4,3]),
+    },
+  },{fromClass:1,toClass:2,minCorner:[0,0],maxCorner:[1,1]},expectedResults,5)
+
     const outputSizeBytes = 16;
 
     type RowType = readonly [number, number, number, number];

--- a/site/src/examples/filter/filter.ts
+++ b/site/src/examples/filter/filter.ts
@@ -58,46 +58,58 @@ function generateFakeDataset(device: GPUDevice, edges: number, cells: number): g
 export function setupDemo(device: GPUDevice, edges: number, cells: number) {
     const { all, any, column, table, select, clause } = given(tableLayout).from('edges');
 
-  const filter = select('$index')
-    .select(table('cells').at('start').dot('gene_x'))
-    .select(table('cells').at('start').dot('subclass'))
-    .select(table('cells').at('end').dot('subclass'))
+    const filter = select('$index')
+        .select(table('cells').at('start').dot('gene_x'))
+        .select(table('cells').at('start').dot('subclass'))
+        .select(table('cells').at('end').dot('subclass'))
         .where(
             all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
                 .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
                 .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
                 .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner'))
         )
-        .build(device,'example');
+        .build(device, 'example');
 
-  const expectedResults = new DataView(new ArrayBuffer(4 * 4 * 2)) // index,gene,sub,sub, 4 bytes each, 2 expected matches
-  expectedResults.setUint32(0, 1,true) // the first edge
-  expectedResults.setFloat32(4, 0.2,true)
-  expectedResults.setUint32(8, 1,true)
-  expectedResults.setUint32(12, 2,true)
+    const expectedResults = new DataView(new ArrayBuffer(4 * 4 * 2)); // index,gene,sub,sub, 4 bytes each, 2 expected matches
+    expectedResults.setUint32(0, 1, true); // the first edge
+    expectedResults.setFloat32(4, 0.2, true);
+    expectedResults.setUint32(8, 1, true);
+    expectedResults.setUint32(12, 2, true);
 
-  expectedResults.setUint32(16, 4,true) // the second match, the 5th edge in the list
-  expectedResults.setFloat32(20, 0.2,true)
-  expectedResults.setUint32(24, 1,true)
-  expectedResults.setUint32(28, 2,true)
-  // for fun, validate at runtime?
-  filter.validate(device, filter.serializeParameters, {
-    cells: {
-      position: new Float32Array([
-        0.5, 0.5,
-        0.25, 0.25,
-        0.5, 0.5,
-        0.5, 0.5,
-        2,2, // excluded by the min/max Corner check
-      ]),
-      subclass:new Uint32Array([0,1,2,2,1]),
-      gene_x:new Float32Array([0.1,0.2,0.3,0.4,0.5]),
-    },
-    edges: {
-      start: new Uint32Array([1,1,4,0,1]),
-      end:   new Uint32Array([0,2,3,4,3]),
-    },
-  },{fromClass:1,toClass:2,minCorner:[0,0],maxCorner:[1,1]},expectedResults,5)
+    expectedResults.setUint32(16, 4, true); // the second match, the 5th edge in the list
+    expectedResults.setFloat32(20, 0.2, true);
+    expectedResults.setUint32(24, 1, true);
+    expectedResults.setUint32(28, 2, true);
+    // for fun, validate at runtime?
+    filter.validate(
+        device,
+        filter.serializeParameters,
+        {
+            cells: {
+                position: new Float32Array([
+                    0.5,
+                    0.5,
+                    0.25,
+                    0.25,
+                    0.5,
+                    0.5,
+                    0.5,
+                    0.5,
+                    2,
+                    2, // excluded by the min/max Corner check
+                ]),
+                subclass: new Uint32Array([0, 1, 2, 2, 1]),
+                gene_x: new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5]),
+            },
+            edges: {
+                start: new Uint32Array([1, 1, 4, 0, 1]),
+                end: new Uint32Array([0, 2, 3, 4, 3]),
+            },
+        },
+        { fromClass: 1, toClass: 2, minCorner: [0, 0], maxCorner: [1, 1] },
+        expectedResults,
+        5
+    );
 
     const outputSizeBytes = 16;
 

--- a/site/src/examples/filter/filter.ts
+++ b/site/src/examples/filter/filter.ts
@@ -38,7 +38,7 @@ function generateFake(dev: GPUDevice, each: (p: number) => number, count: number
 
 const tableLayout = {
     cells: { subclass: 'u32', gene_x: 'f32', position: 'vec2f' },
-    edges: { start: 'u32', end: 'u32'},
+    edges: { start: 'u32', end: 'u32' },
 } as const;
 type gpuDataset = {
     cells: { [k in keyof (typeof tableLayout)['cells']]: GPUBuffer };
@@ -52,32 +52,34 @@ function generateFakeDataset(device: GPUDevice, edges: number, cells: number): g
     const start = generateFake(device, (r) => Math.floor(r * cells), edges, 'u32');
     const end = generateFake(device, (r) => Math.floor(r * cells), edges, 'u32');
     const str = generateFake(device, (r) => 1.0 + r * 22.0, edges, 'f32');
-    return { cells: { position: positions, subclass, gene_x }, edges: { start, end, } };
+    return { cells: { position: positions, subclass, gene_x }, edges: { start, end } };
 }
 
 export function setupDemo(device: GPUDevice, edges: number, cells: number) {
-  const {all,any,column,table,select,clause } = given(tableLayout)
-    .from('edges');
+    const { all, any, column, table, select, clause } = given(tableLayout).from('edges');
 
-  const filter = select('$index')
-    .select(table('cells').at('start').dot('gene_x'))
-    .select(table('cells').at('start').dot('subclass'))
-    .select(table('cells').at('end').dot('subclass'))
-    .where(all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
-      .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
-      .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
-      .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner'))).build(device);
-  // .select('$index')
-      //   .select()
-        // .select('cells[start].gene_x')
-        // .select('cells[start].subclass')
-        // .select('cells[end].subclass')
-        // .where('cells[end].subclass == toClass')
-        // .andOpen('cells[start].subclass == fromClass')
-        // .and('cells[start].position all(>=) minCorner')
-        // .and('cells[start].position all(<) maxCorner')
-        // .close()
-        // .build(device, 'testing');
+    const filter = select('$index')
+        .select(table('cells').at('start').dot('gene_x'))
+        .select(table('cells').at('start').dot('subclass'))
+        .select(table('cells').at('end').dot('subclass'))
+        .where(
+            all(clause(table('cells').at('end').dot('subclass'), '==', 'toClass'))
+                .and(clause(table('cells').at('start').dot('subclass'), '==', 'fromClass'))
+                .and(clause(table('cells').at('start').dot('position'), 'all(>=)', 'minCorner'))
+                .and(clause(table('cells').at('start').dot('position'), 'all(<)', 'maxCorner'))
+        )
+        .build(device);
+    // .select('$index')
+    //   .select()
+    // .select('cells[start].gene_x')
+    // .select('cells[start].subclass')
+    // .select('cells[end].subclass')
+    // .where('cells[end].subclass == toClass')
+    // .andOpen('cells[start].subclass == fromClass')
+    // .and('cells[start].position all(>=) minCorner')
+    // .and('cells[start].position all(<) maxCorner')
+    // .close()
+    // .build(device, 'testing');
     const outputSizeBytes = 16;
 
     type RowType = readonly [number, number, number, number];


### PR DESCRIPTION


# What

the initial implementation of filtering did not support some features (like referring to the .x or .y value of a vector column) that were critical for the actual filters we need in our use case. Making this all work required a bit of a rewrite, but its much more capable now, and the "andOpen" style syntax, which was confusing, is now replaced with something that is still a bit confusing, but better and you get more power from it.

# How

use a builder-style expression system, rather than very fragile typescript template-string types.

# Screenshots

_This section is optional if there are no visible changes_

- If possible add screenshots of the visible additions in the UI.
- If there are changes in the UI, add **Before** and **After** Screenshots for quick overview.
- If there was a Figma design, add a link to that here as well.
- Hint : Drag and Drop any images you want to add to the PR. Also you can create a gif of an interactive version and add that!

# PR Checklist

- [ ] Is your PR title following our conventional commit naming recommendations?
- [ ] Have you filled in the PR Description Template?
- [ ] Is your branch up to date with the latest in `main`?
- [ ] Do the CI checks pass successfully?
- [ ] Have you smoke tested the example applications?
- [ ] Did you check that the changes meet accessibility standards?
- [ ] Have you tested the application on these browsers?
    - [ ] Chrome (Fully supported)
    - [ ] Firefox (Major bug fixes supported)
    - [ ] Safari (Major bug fixes supported)
