### PR TITLE
fix(vis-core): filter compute shaders incorrectly handled alignment of vec3 columns

### DIFF
--- a/packages/core/src/rendering/webgpu/filter/aggregate/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/aggregate/gen.ts
@@ -99,7 +99,7 @@ export function generateAggregationShader(
     col: G,
     row?: G
 ) {
-    const toWgsl = setupExprBuilder(from);
+    const toWgsl = setupExprBuilder(from, tables);
 
     let bindingStart = 1;
     let bindings: string = '';

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -38,34 +38,37 @@ function parseVecOp(op: VOP) {
     return [aggregation, sop] as ['any' | 'all', OP];
 }
 export function setupExprBuilder(from: string, tables: Tables) {
-    function columnAt(table: string, column: string, indexing: string) {
+    function columnAt(table: string, column: string, indexing: string, swizzle: string | undefined) {
         const type = tables[table][column];
         if (type.startsWith('vec3')) {
             // webGPU can handle vec3 as vertex data (tight 12byte pack) but not in a storage buffer, because why be nice to developers?
             // so we do this silly hack:
+            const offsets: Record<string, string> = { x: '0', y: '1', z: '2' };
+            if (swizzle) {
+                if (swizzle in offsets) {
+                    const offset = offsets[swizzle];
+                    return `${table}_${column}[(${indexing})*3+${offset}]`;
+                }
+            }
             return `${type}(${table}_${column}[(${indexing})*3],${table}_${column}[(${indexing})*3+1],${table}_${column}[(${indexing})*3+2])`;
         }
         // otherwise, be normal about stuff
-        return `${table}_${column}[${indexing}]`;
+        return swizzle ? `${table}_${column}[${indexing}].${swizzle}` : `${table}_${column}[${indexing}]`;
     }
 
     function toWgsl(ast: AST, indexing: string, uniName: string): string {
         switch (ast.kind) {
             case 'from field': {
                 const [column, swizzle] = ast.field.split('.');
-                // if the column is a vec3*, we have to massage the index... due to alignment issues!
-                return swizzle
-                    ? `${columnAt(ast.from, column, indexing)}.${swizzle}`
-                    : `${columnAt(ast.from, column, indexing)}`;
+                return columnAt(ast.from, column, indexing, swizzle);
             }
             case 'table at field':
                 const subExpr =
                     typeof ast.atExpr === 'string'
-                        ? `[${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: 'u32' }, indexing, uniName)}]`
-                        : `[${toWgsl(ast.atExpr, indexing, uniName)}]`;
+                        ? `${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: 'u32' }, indexing, uniName)}`
+                        : `${toWgsl(ast.atExpr, indexing, uniName)}`;
                 const [column, swizzle] = ast.field.split('.');
-                const sel: string = columnAt(ast.table, column, subExpr); //`${ast.table}_${column}${subExpr}`;
-                return swizzle ? `${sel}.${swizzle}` : sel;
+                return columnAt(ast.table, column, subExpr, swizzle);
             case 'predicate':
                 const { lhs, op, rhs } = ast;
                 if (isVecOp(op)) {

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -49,6 +49,8 @@ export function setupExprBuilder(from: string, tables: Tables) {
                     const offset = offsets[swizzle];
                     return `${table}_${column}[(${indexing})*3+${offset}]`;
                 }
+                // if somehow, the swizzle isn't x,y,z, which should be impossible - lets just make a vec3 and append the swizzle expr to it anyway:
+                return `${type}(${table}_${column}[(${indexing})*3],${table}_${column}[(${indexing})*3+1],${table}_${column}[(${indexing})*3+2]).${swizzle}`;
             }
             return `${type}(${table}_${column}[(${indexing})*3],${table}_${column}[(${indexing})*3+1],${table}_${column}[(${indexing})*3+2])`;
         }

--- a/packages/core/src/rendering/webgpu/filter/gen.ts
+++ b/packages/core/src/rendering/webgpu/filter/gen.ts
@@ -1,6 +1,15 @@
-import { type WgslType, type Sel, type Tables, type AST, type OP, type VOP } from './types';
-
-const entries = (r: object) => Object.entries(r);
+import { entries } from 'lodash-es';
+import {
+    type WgslType,
+    type Sel,
+    type Tables,
+    type AST,
+    type OP,
+    type VOP,
+    type VectorType,
+    type VLen,
+    type ScalarType,
+} from './types';
 
 function generateOutputStructure(selections: ReadonlyArray<Sel>) {
     // the names of the values in the structure dont matter at all -
@@ -15,17 +24,39 @@ function generateOutputStructure(selections: ReadonlyArray<Sel>) {
 function isVecOp(s: OP | VOP): s is VOP {
     return s.startsWith('a');
 }
+function scalarTypeOf(type: VectorType<VLen>): ScalarType {
+    if (type.endsWith('u')) {
+        return 'u32';
+    } else if (type.endsWith('f')) {
+        return 'f32';
+    }
+    return 'i32';
+}
 function parseVecOp(op: VOP) {
     const aggregation = op.substring(0, 3);
     const sop = op.substring(4).split(')')[0];
     return [aggregation, sop] as ['any' | 'all', OP];
 }
-export function setupExprBuilder(from: string) {
+export function setupExprBuilder(from: string, tables: Tables) {
+    function columnAt(table: string, column: string, indexing: string) {
+        const type = tables[table][column];
+        if (type.startsWith('vec3')) {
+            // webGPU can handle vec3 as vertex data (tight 12byte pack) but not in a storage buffer, because why be nice to developers?
+            // so we do this silly hack:
+            return `${type}(${table}_${column}[(${indexing})*3],${table}_${column}[(${indexing})*3+1],${table}_${column}[(${indexing})*3+2])`;
+        }
+        // otherwise, be normal about stuff
+        return `${table}_${column}[${indexing}]`;
+    }
+
     function toWgsl(ast: AST, indexing: string, uniName: string): string {
         switch (ast.kind) {
             case 'from field': {
                 const [column, swizzle] = ast.field.split('.');
-                return swizzle ? `${ast.from}_${column}[${indexing}].${swizzle}` : `${ast.from}_${column}[${indexing}]`;
+                // if the column is a vec3*, we have to massage the index... due to alignment issues!
+                return swizzle
+                    ? `${columnAt(ast.from, column, indexing)}.${swizzle}`
+                    : `${columnAt(ast.from, column, indexing)}`;
             }
             case 'table at field':
                 const subExpr =
@@ -33,7 +64,7 @@ export function setupExprBuilder(from: string) {
                         ? `[${toWgsl({ kind: 'from field', field: ast.atExpr, from: from as string, type: 'u32' }, indexing, uniName)}]`
                         : `[${toWgsl(ast.atExpr, indexing, uniName)}]`;
                 const [column, swizzle] = ast.field.split('.');
-                const sel: string = `${ast.table}_${column}${subExpr}`;
+                const sel: string = columnAt(ast.table, column, subExpr); //`${ast.table}_${column}${subExpr}`;
                 return swizzle ? `${sel}.${swizzle}` : sel;
             case 'predicate':
                 const { lhs, op, rhs } = ast;
@@ -123,9 +154,10 @@ export function generateTableBindings(
         {} as Record<string, number>
     );
     const decls = cols
-        .map(
-            ([f, t], index) =>
-                `@group(${group}) @binding(${index + bindingStart}) var<storage,read> ${tableName}_${f}: array<${t}>;`
+        .map(([f, t], index) =>
+            t.startsWith('vec3')
+                ? `@group(${group}) @binding(${index + bindingStart}) var<storage,read> ${tableName}_${f}: array<${scalarTypeOf(t as VectorType<3>)}>;`
+                : `@group(${group}) @binding(${index + bindingStart}) var<storage,read> ${tableName}_${f}: array<${t}>;`
         )
         .join('\n');
     return { decls, numBindings: cols.length, bindingLookup };

--- a/packages/core/src/rendering/webgpu/filter/query.test.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { given } from './query';
+import { setupExprBuilder } from './gen';
 
 describe('expression building', () => {
     const tables = {
@@ -74,6 +75,21 @@ describe('expression building', () => {
             rhs: 'stuff',
         });
     });
+    describe('vec3 input handling', () => {
+        const tables = {
+            cells: { A: 'vec3f', B: 'u32' },
+        } as const;
+        test('vec3 columns are re-written as scalar arrays', () => {
+            const c = given(tables).from('cells');
+            const regular = c.column('A');
+            const swizzledRef = c.column('A.x');
+            const toWgsl = setupExprBuilder('cells', tables);
+            expect(toWgsl(regular, 'element', 'params')).toEqual(
+                'vec3f(cells_A[(element)*3],cells_A[(element)*3+1],cells_A[(element)*3+2])'
+            );
+            expect(toWgsl(swizzledRef, 'element', 'params')).toEqual('cells_A[(element)*3+0]');
+        });
+    });
     describe('aggregation shader', () => {
         const tables = {
             cells: { A: 'vec2f', B: 'u32' },
@@ -99,7 +115,7 @@ describe('expression building', () => {
         };
         @group(0) @binding(0)
         var<uniform> outputDimensions: vec2u;
-        
+
    //cells
   @group(1) @binding(1) var<storage,read> cells_A: array<vec2f>;
   @group(1) @binding(2) var<storage,read> cells_B: array<u32>;

--- a/packages/core/src/rendering/webgpu/filter/query.ts
+++ b/packages/core/src/rendering/webgpu/filter/query.ts
@@ -151,7 +151,7 @@ class Selection<Ts extends Tables, From extends keyof Ts> {
         selections: ReadonlyArray<Sel>
     ) {
         this.selections = selections;
-        this.toWgsl = setupExprBuilder(this.from as string);
+        this.toWgsl = setupExprBuilder(this.from as string, tables);
     }
     select(selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>) {
         const s = selection === '$index' ? 'tmp - 1' : this.toWgsl(selection, 'tmp - 1', ''); // uni-name not relavant in selection...
@@ -576,7 +576,7 @@ export function given<Ts extends Tables>(tables: Ts) {
                 };
             }
 
-            const toWgsl = setupExprBuilder(from as string);
+            const toWgsl = setupExprBuilder(from as string, tables);
             function select(
                 selection: '$index' | IndexExpr<string, string, WgslType> | ColumnExpr<string, string, WgslType>
             ) {

--- a/site/src/examples/filter/demo.tsx
+++ b/site/src/examples/filter/demo.tsx
@@ -12,8 +12,8 @@ export function Demo() {
     const [gpuDuration, setGpuDuration] = useState<number>(Number.NaN);
     const [gpuAggregationDuration, setAggregationGpuDuration] = useState<number>(Number.NaN);
     const [params, setParams] = useState<Parameters<ReturnType<typeof setupDemo>>[0]>({
-        minCorner: [0, 0],
-        maxCorner: [1, 1],
+        minCorner: [0, 0, 0],
+        maxCorner: [1, 1, 1],
         fromClass: 3,
         toClass: 4,
     });

--- a/site/src/examples/filter/filter.ts
+++ b/site/src/examples/filter/filter.ts
@@ -182,7 +182,9 @@ export function setupDemo(device: GPUDevice, edges: number, cells: number) {
             5
         )
         .then((result) => {
-            console.warn(result);
+            if (result.status === 'failure') {
+                throw new Error('warning - demo filter failed to validate!');
+            }
         });
 
     const outputSizeBytes = 16;

--- a/site/src/examples/filter/filter.ts
+++ b/site/src/examples/filter/filter.ts
@@ -44,7 +44,7 @@ function generateFake(
 }
 
 const tableLayout = {
-    cells: { subclass: 'u32', gene_x: 'f32', position: 'vec2f' },
+    cells: { subclass: 'u32', gene_x: 'f32', position: 'vec3f' },
     edges: { start: 'u32', end: 'u32' },
 } as const;
 const aggLayout = {
@@ -146,35 +146,44 @@ export function setupDemo(device: GPUDevice, edges: number, cells: number) {
     expectedResults.setUint32(24, 1, true);
     expectedResults.setUint32(28, 2, true);
     // for fun, validate at runtime?
-    filter.validate(
-        device,
-        filter.serializeParameters,
-        {
-            cells: {
-                position: new Float32Array([
-                    0.5,
-                    0.5,
-                    0.25,
-                    0.25,
-                    0.5,
-                    0.5,
-                    0.5,
-                    0.5,
-                    2,
-                    2, // excluded by the min/max Corner check
-                ]),
-                subclass: new Uint32Array([0, 1, 2, 2, 1]),
-                gene_x: new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5]),
+    filter
+        .validate(
+            device,
+            filter.serializeParameters,
+            {
+                cells: {
+                    position: new Float32Array([
+                        0.5,
+                        0.5,
+                        0.333,
+                        0.25,
+                        0.25,
+                        0.333,
+                        0.5,
+                        0.5,
+                        0.333,
+                        0.5,
+                        0.5,
+                        0.333,
+                        2,
+                        2,
+                        0.333, // excluded by the min/max Corner check
+                    ]),
+                    subclass: new Uint32Array([0, 1, 2, 2, 1]),
+                    gene_x: new Float32Array([0.1, 0.2, 0.3, 0.4, 0.5]),
+                },
+                edges: {
+                    start: new Uint32Array([1, 1, 4, 0, 1]),
+                    end: new Uint32Array([0, 2, 3, 4, 3]),
+                },
             },
-            edges: {
-                start: new Uint32Array([1, 1, 4, 0, 1]),
-                end: new Uint32Array([0, 2, 3, 4, 3]),
-            },
-        },
-        { fromClass: 1, toClass: 2, minCorner: [0, 0], maxCorner: [1, 1] },
-        expectedResults,
-        5
-    );
+            { fromClass: 1, toClass: 2, minCorner: [0, 0, 0], maxCorner: [1, 1, 1] },
+            expectedResults,
+            5
+        )
+        .then((result) => {
+            console.warn(result);
+        });
 
     const outputSizeBytes = 16;
 
@@ -191,8 +200,8 @@ export function setupDemo(device: GPUDevice, edges: number, cells: number) {
     const params = filter.serializeParameters({
         toClass: 4,
         fromClass: 3,
-        minCorner: [0, 0],
-        maxCorner: [0.9, 0.9],
+        minCorner: [0, 0, 0],
+        maxCorner: [0.9, 0.9, 0.9],
     });
     const paramBuffer = device.createBuffer({
         size: params.byteLength,


### PR DESCRIPTION
# Fix compute shader handling of vec3 columns

# What
- [x] fixes a potential bug in how vec3 data is handled in webGPU compute shaders - see https://toji.dev/webgpu-best-practices/compute-vertex-data for good background info
- [x] unit tests
# How
- [x] when generating a shader that access vec3 "column" data, instead re-write the shader to access that data as an array of scalars, rather than vectors - such an array magically avoids any alignment problems... accesses of the given column are then re-written to compose vector values manually, using manual indexing calculations.
# Screenshots

_This section is optional if there are no visible changes_

- If possible add screenshots of the visible additions in the UI.
- If there are changes in the UI, add **Before** and **After** Screenshots for quick overview.
- If there was a Figma design, add a link to that here as well.
- Hint : Drag and Drop any images you want to add to the PR. Also you can create a gif of an interactive version and add that!

# PR Checklist

- [ ] Is your PR title following our conventional commit naming recommendations?
- [ ] Have you filled in the PR Description Template?
- [ ] Is your branch up to date with the latest in `main`?
- [ ] Do the CI checks pass successfully?
- [ ] Have you smoke tested the example applications?
- [ ] Did you check that the changes meet accessibility standards?
- [ ] Have you tested the application on these browsers?
    - [ ] Chrome (Fully supported)
    - [ ] Firefox (Major bug fixes supported)
    - [ ] Safari (Major bug fixes supported)
